### PR TITLE
meta: fix small typos in roadmap

### DIFF
--- a/book/01-02-roadmap.md
+++ b/book/01-02-roadmap.md
@@ -8,11 +8,11 @@
 - [x] VMM
 - [x] Parse MADT
 - [x] apic (ioapic/lapic)
-- [x] pit
-- [x] apic timer
+- [x] HPET
+- [x] APIC timer
 - [x] SMP
 - [X] Multi tasking
-- [X] Sheduling
+- [X] Scheduling
 - [x] Userspace
 - [X] Syscalls
 - [x] SIMD (avx, sse, fpu, xsave)


### PR DESCRIPTION
Changed the PIT Milestone to HPET since the PIT isn't used in the kernel anymore.