### PR TITLE
make: use Os optimization

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ CFLAGS_STD ?= \
 	-std=gnu2x
 
 CFLAGS_OPT ?= \
-	-g
+	-g -Os
 
 CFLAGS_WARN ?= \
 	-Wall \


### PR DESCRIPTION
I think using -Os  is better with this microkernel because of caching, if we have a small kernel (currently with clang we have a 300kb kernel and 517kb with gcc ) it will be easier for the cpu to cache it.  (+ Now the kernel is super fast)