### PR TITLE
Feat: add basic EFI library

### DIFF
--- a/sources/libs/.build.mk
+++ b/sources/libs/.build.mk
@@ -1,6 +1,7 @@
 LIBS_BIN = $(BUILDDIR_CROSS)/libbrutal.a
 
 LIBS_SRC = \
+	$(wildcard sources/libs/efi/*.c)               \
 	$(wildcard sources/libs/ansi/*.c)               \
 	$(wildcard sources/libs/brutal/*.c)             \
 	$(wildcard sources/libs/brutal/*/*.c)           \

--- a/sources/libs/efi/base.h
+++ b/sources/libs/efi/base.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define EFI_SUCCESS 0
+
+#define UNUSED(x) (void)x
+
+typedef unsigned short char16;
+typedef unsigned long long EFIStatus;
+typedef void *EFIEvent;
+typedef void *EFIHandle;
+
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+
+typedef struct
+{
+    u16 year;
+    u8 month;
+    u8 pad1;
+    u32 nanosecond;
+    int16_t time_zone;
+    u8 daylight;
+    u8 pad2;
+} EFITime;
+
+typedef struct
+{
+    u32 resolution;
+    u32 accuracy;
+    bool sets_to_zero;
+} EFITimeCapabilities;
+
+typedef struct
+{
+    u32 data1;
+    u16 data2;
+    u16 data3;
+    u8 data4[8];
+} EFIGUID;
+
+typedef struct
+{
+    u32 type;
+    u64 physical_start;
+    u64 virtual_start;
+    u64 num_pages;
+    u64 attribute;
+} EFIMemoryDescriptor;
+
+typedef struct
+{
+    u64 signature;
+    u32 revision;
+    u32 header_size;
+    u32 CRC32;
+    u32 reserved;
+} EFITableHeader;

--- a/sources/libs/efi/bs.h
+++ b/sources/libs/efi/bs.h
@@ -1,0 +1,173 @@
+#pragma once
+
+#include <efi/base.h>
+#include <efi/dpp.h>
+
+/* Event Types */
+#define EVT_TIMER 0x80000000
+#define EVT_RUNTIME 0x40000000
+#define EVT_NOTIFY_WAIT 0x00000100
+#define EVT_NOTIFY_SIGNAL 0x00000200
+#define EVT_SIGNAL_EXIT_BOOT_SERVICES 0x00000201
+#define EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE 0x00000202
+
+#define TPL_APPLICATION 4
+#define TPL_CALLBACK 8
+#define TPL_NOTIFY 16
+#define TPL_HIGH_LEVEL 31
+
+#define EFI_OPEN_PROTOCOL_BY_HANDLE_PROTOCOL 0x00000001
+#define EFI_OPEN_PROTOCOL_GET_PROTOCOL 0x00000002
+#define EFI_OPEN_PROTOCOL_TEST_PROTOCOL 0x00000004
+#define EFI_OPEN_PROTOCOL_BY_CHILD_CONTROLLER 0x00000008
+#define EFI_OPEN_PROTOCOL_BY_DRIVER 0x00000010
+#define EFI_OPEN_PROTOCOL_EXCLUSIVE 0x00000020
+
+#define EFI_RESERVED_MEMORY_TYPE 0x00000000
+#define EFI_LOADER_CODE 0x00000001
+#define EFI_LOADER_DATA 0x00000002
+#define EFI_BOOT_SERVICES_CODE 0x00000003
+#define EFI_BOOT_SERVICES_DATA 0x00000004
+#define EFI_RUNTIME_SERVICES_CODE 0x00000005
+#define EFI_RUNTIME_SERVICES_DATA 0x00000006
+#define EFI_CONVENTIONAL_MEMORY 0x00000007
+#define EFI_UNUSABLE_MEMORY 0x00000008
+#define EFI_ACPI_RECLAIM_MEMORY 0x00000009
+#define EFI_ACPI_MEMORY_NVS 0x0000000a
+#define EFI_MEMORY_MAPPED_IO 0x0000000b
+#define EFI_MEMORY_MAPPED_IO_PORT_SPACE 0x0000000c
+#define EFI_PAL_CODE 0x0000000d
+#define EFI_PERSISTENT_MEMORY 0x0000000e
+#define EFI_MAX_MEMORY_TYPE 0x0000000e
+
+typedef void (*EFIEventNotifyFunction)(EFIEvent, void *);
+
+typedef enum
+{
+    timer_cncel,
+    timer_periodic,
+    timer_relative
+} EFITimerDelay;
+
+typedef enum
+{
+    ALLOCATE_ANY_PAGES,
+    ALLOCATE_MAX_ADDRESS,
+    ALLOCATE_ADDRESS,
+    MAX_ALLOCATE_TYPE
+} EFIAllocateType;
+
+typedef enum
+{
+    EFI_NATIVE_INTERFACE
+} EFIInterfaceType;
+
+typedef enum
+{
+    ALL_HANDLES,
+    BY_REGISTER_NOTIFY,
+    BY_PROTOCOL
+} EFILocateSearchType;
+
+typedef struct EFI_OPEN_PROTOCOL_INFORMATION_ENTRY
+{
+    EFIHandle agent_handle;
+    EFIHandle controller_handle;
+    u32 attributes;
+    u32 open_count;
+} EFIOpenProtocolInformationEntry;
+
+#define DEF_EFI_FUNC(name, ...) typedef EFIStatus (*EFI_##name)(__VA_ARGS__)
+
+DEF_EFI_FUNC(RAISE_TPL, u64);
+DEF_EFI_FUNC(RESTORE_TPL, u64);
+DEF_EFI_FUNC(ALLOCATE_PAGES, EFIAllocateType, u64, u64, u64 *);
+DEF_EFI_FUNC(FREE_PAGES, u64, u64);
+DEF_EFI_FUNC(GET_MEMORY_MAP, u64 *, EFIMemoryDescriptor *, u64 *, u64 *, u32 *);
+DEF_EFI_FUNC(ALLOCATE_POOL, u64, u64, void **);
+DEF_EFI_FUNC(FREE_POOL, void *);
+DEF_EFI_FUNC(CREATE_EVENT, u32, u64, EFIEventNotifyFunction, void *, EFIGUID *, EFIEvent *);
+DEF_EFI_FUNC(SET_TIMER, EFIEvent, EFITimerDelay, u64);
+DEF_EFI_FUNC(WAIT_FOR_EVENT, u64, EFIEvent *, u64 *);
+DEF_EFI_FUNC(SIGNAL_EVENT, EFIEvent);
+DEF_EFI_FUNC(CLOSE_EVENT, EFIEvent);
+DEF_EFI_FUNC(CHECK_EVENT, EFIEvent);
+DEF_EFI_FUNC(INSTALL_PROTOCOL_INTERFACE, EFIHandle *, EFIGUID *, EFIInterfaceType, void *);
+DEF_EFI_FUNC(REINSTALL_PROTOCOL_INTERFACE, EFIHandle, EFIGUID *, void *, void *);
+DEF_EFI_FUNC(UNINSTALL_PROTOCOL_INTERFACE, EFIHandle, EFIGUID *, void *);
+DEF_EFI_FUNC(HANDLE_PROTOCOL, EFIHandle, EFIGUID *, void **);
+DEF_EFI_FUNC(REGISTER_PROTOCOL_NOTIFY, EFIGUID *, EFIEvent, void **);
+DEF_EFI_FUNC(LOCATE_HANDLE, EFILocateSearchType, EFIGUID *, void *, u64 *, EFIHandle);
+DEF_EFI_FUNC(LOCATE_DEVICE_PATH, EFIGUID *, EFIDevicePath **, EFIHandle);
+DEF_EFI_FUNC(INSTALL_CONFIGURATION_TABLE, EFIGUID *, void *);
+DEF_EFI_FUNC(IMAGE_LOAD, bool, EFIHandle, EFIDevicePath *, void *, u64, EFIHandle *);
+DEF_EFI_FUNC(IMAGE_START, EFIHandle, u64 *, char16 **);
+DEF_EFI_FUNC(EXIT, EFIHandle, EFIStatus, u64, char16 *);
+DEF_EFI_FUNC(IMAGE_UNLOAD, EFIHandle);
+DEF_EFI_FUNC(EXIT_BOOT_SERVICES, EFIHandle, u64);
+DEF_EFI_FUNC(GET_NEXT_MONOTONIC_COUNT, u64 *);
+DEF_EFI_FUNC(STALL, u64);
+DEF_EFI_FUNC(SET_WATCHDOG_TIMER, u64, u64, u64, char16 *);
+DEF_EFI_FUNC(CONNECT_CONTROLLER, EFIHandle, EFIHandle *, EFIDevicePath *, bool);
+DEF_EFI_FUNC(DISCONNECT_CONTROLLER, EFIHandle, EFIHandle, EFIHandle);
+DEF_EFI_FUNC(OPEN_PROTOCOL, EFIHandle, EFIGUID *, void **, EFIHandle, EFIHandle, u32);
+DEF_EFI_FUNC(CLOSE_PROTOCOL, EFIHandle, EFIGUID *, EFIHandle, EFIHandle);
+DEF_EFI_FUNC(OPEN_PROTOCOL_INFORMATION, EFIHandle, EFIGUID *, EFIOpenProtocolInformationEntry **, u64 *);
+DEF_EFI_FUNC(PROTOCOLS_PER_HANDLE, EFIHandle, EFIGUID **, u64 *);
+DEF_EFI_FUNC(LOCATE_HANDLE_BUFFER, EFILocateSearchType, EFIGUID *, void *, u64 *, EFIHandle **);
+DEF_EFI_FUNC(LOCATE_PROTOCOL, EFIGUID *, void *, void **);
+DEF_EFI_FUNC(INSTALL_MULTIPLE_PROTOCOL_INTERFACES, EFIHandle *, ...);
+DEF_EFI_FUNC(UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES, EFIHandle *, ...);
+DEF_EFI_FUNC(CALCULATE_CRC32, void *, u64, u32 *);
+DEF_EFI_FUNC(COPY_MEM, void *, void *, u64);
+DEF_EFI_FUNC(SET_MEM, void *, u64, u8);
+DEF_EFI_FUNC(CREATE_EVENT_EX, u32, u64, EFIEventNotifyFunction, void *, EFIGUID *, EFIEvent *);
+
+typedef struct
+{
+    EFITableHeader hdr;
+    EFI_RAISE_TPL raise_tpl;
+    EFI_RESTORE_TPL restore_tpl;
+    EFI_ALLOCATE_PAGES allocate_pages;
+    EFI_FREE_PAGES free_pages;
+    EFI_GET_MEMORY_MAP get_memory_map;
+    EFI_ALLOCATE_POOL allocate_pool;
+    EFI_FREE_POOL free_pool;
+    EFI_CREATE_EVENT create_event;
+    EFI_SET_TIMER set_timer;
+    EFI_WAIT_FOR_EVENT wait_for_event;
+    EFI_SIGNAL_EVENT signal_event;
+    EFI_CLOSE_EVENT close_event;
+    EFI_CHECK_EVENT check_event;
+    EFI_INSTALL_PROTOCOL_INTERFACE install_protocol_interface;
+    EFI_REINSTALL_PROTOCOL_INTERFACE reinstall_protocol_interface;
+    EFI_UNINSTALL_PROTOCOL_INTERFACE uninstall_protocol_interface;
+    EFI_HANDLE_PROTOCOL handle_protocol;
+    void *reserved;
+    EFI_REGISTER_PROTOCOL_NOTIFY register_protocol_notify;
+    EFI_LOCATE_HANDLE locate_handle;
+    EFI_LOCATE_DEVICE_PATH locate_device_path;
+    EFI_INSTALL_CONFIGURATION_TABLE install_configuration_table;
+    EFI_IMAGE_LOAD load_image;
+    EFI_IMAGE_START start_image;
+    EFI_EXIT exit;
+    EFI_IMAGE_UNLOAD unload_image;
+    EFI_EXIT_BOOT_SERVICES exit_boot_services;
+    EFI_GET_NEXT_MONOTONIC_COUNT get_next_monotonic_count;
+    EFI_STALL stall;
+    EFI_SET_WATCHDOG_TIMER set_watchdog_timer;
+    EFI_CONNECT_CONTROLLER connect_controller;
+    EFI_DISCONNECT_CONTROLLER disconnect_controller;
+    EFI_OPEN_PROTOCOL open_protocol;
+    EFI_CLOSE_PROTOCOL close_protocol;
+    EFI_OPEN_PROTOCOL_INFORMATION open_protocol_information;
+    EFI_PROTOCOLS_PER_HANDLE protocols_per_handle;
+    EFI_LOCATE_HANDLE_BUFFER locate_handle_buffer;
+    EFI_LOCATE_PROTOCOL locate_protocol;
+    EFI_INSTALL_MULTIPLE_PROTOCOL_INTERFACES install_multiple_protocol_interfaces;
+    EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES uninstall_multiple_protocol_interfaces;
+    EFI_CALCULATE_CRC32 calculate_crc32;
+    EFI_COPY_MEM copy_mem;
+    EFI_SET_MEM set_mem;
+    EFI_CREATE_EVENT_EX create_event_ex;
+} EFIBootServices;

--- a/sources/libs/efi/console.h
+++ b/sources/libs/efi/console.h
@@ -1,0 +1,121 @@
+#pragma once
+#include <efi/base.h>
+
+/* ---------- output -------------- */
+#define EFI_BLACK 0x00
+#define EFI_BLUE 0x01
+#define EFI_GREEN 0x02
+#define EFI_CYAN (EFI_BLUE | EFI_GREEN)
+#define EFI_RED 0x04
+#define EFI_MAGENTA (EFI_BLUE | EFI_RED)
+#define EFI_BROWN (EFI_GREEN | EFI_RED)
+#define EFI_LIGHTGRAY (EFI_BLUE | EFI_GREEN | EFI_RED)
+#define EFI_BRIGHT 0x08
+#define EFI_DARKGRAY (EFI_BRIGHT)
+#define EFI_LIGHTBLUE (EFI_BLUE | EFI_BRIGHT)
+#define EFI_LIGHTGREEN (EFI_GREEN | EFI_BRIGHT)
+#define EFI_LIGHTCYAN (EFI_CYAN | EFI_BRIGHT)
+#define EFI_LIGHTRED (EFI_RED | EFI_BRIGHT)
+#define EFI_LIGHTMAGENTA (EFI_MAGENTA | EFI_BRIGHT)
+#define EFI_YELLOW (EFI_BROWN | EFI_BRIGHT)
+#define EFI_WHITE (EFI_BLUE | EFI_GREEN | EFI_RED | EFI_BRIGHT)
+
+#define EFI_BACKGROUND_BLACK 0x00
+#define EFI_BACKGROUND_BLUE 0x10
+#define EFI_BACKGROUND_GREEN 0x20
+#define EFI_BACKGROUND_CYAN (EFI_BACKGROUND_BLUE | EFI_BACKGROUND_GREEN)
+#define EFI_BACKGROUND_RED 0x40
+#define EFI_BACKGROUND_MAGENTA (EFI_BACKGROUND_BLUE | EFI_BACKGROUND_RED)
+#define EFI_BACKGROUND_BROWN (EFI_BACKGROUND_GREEN | EFI_BACKGROUND_RED)
+#define EFI_BACKGROUND_LIGHTGRAY (EFI_BACKGROUND_BLUE | EFI_BACKGROUND_GREEN | EFI_BACKGROUND_RED)
+
+struct _EFI_SIMPLE_TEXT_OUTPUT;
+
+#define DEF_TEXTO_EFI_FUNC(name, ...) typedef EFIStatus (*EFI_TEXTO_##name)(struct _EFI_SIMPLE_TEXT_OUTPUT * self __VA_OPT__(, ) __VA_ARGS__)
+
+DEF_TEXTO_EFI_FUNC(RESET, bool verification);
+DEF_TEXTO_EFI_FUNC(OUTPUT_STRING, char16 *string);
+DEF_TEXTO_EFI_FUNC(TEST_STRING, char16 *string);
+DEF_TEXTO_EFI_FUNC(QUERY_MODE, u32 mode_number, u32 *columns, u32 *rows);
+DEF_TEXTO_EFI_FUNC(SET_MODE, u32 mode_number);
+DEF_TEXTO_EFI_FUNC(SET_ATTRIBUTE, u32 attribute);
+DEF_TEXTO_EFI_FUNC(CLEAR_SCREEN);
+DEF_TEXTO_EFI_FUNC(SET_CURSOR_POSITION, u32 column, u32 row);
+DEF_TEXTO_EFI_FUNC(ENABLE_CURSOR, bool visible);
+
+typedef struct
+{
+    int32_t max_mode;
+    int32_t mode;
+    int32_t attribute;
+    int32_t cursor_column;
+    int32_t cursor_row;
+    bool cursor_visible;
+} SimpleTextOutputMode;
+
+typedef struct _EFI_SIMPLE_TEXT_OUTPUT
+{
+    EFI_TEXTO_RESET reset;
+    EFI_TEXTO_OUTPUT_STRING output_string;
+    EFI_TEXTO_TEST_STRING test_string;
+    EFI_TEXTO_QUERY_MODE query_mode;
+    EFI_TEXTO_SET_MODE set_mode;
+    EFI_TEXTO_SET_ATTRIBUTE set_attribute;
+    EFI_TEXTO_CLEAR_SCREEN clear_screen;
+    EFI_TEXTO_SET_CURSOR_POSITION set_cursor_position;
+    EFI_TEXTO_ENABLE_CURSOR enable_cursor;
+    SimpleTextOutputMode *mode;
+
+} EFISimpleTextOutput;
+
+/* -------------- input --------------- */
+#define CHAR_CARRIAGE_RETURN            0x000D
+#define SCAN_NULL 0x0000
+#define SCAN_UP 0x0001
+#define SCAN_DOWN 0x0002
+#define SCAN_RIGHT 0x0003
+#define SCAN_LEFT 0x0004
+#define SCAN_HOME 0x0005
+#define SCAN_END 0x0006
+#define SCAN_INSERT 0x0007
+#define SCAN_DELETE 0x0008
+#define SCAN_PAGE_UP 0x0009
+#define SCAN_PAGE_DOWN 0x000A
+#define SCAN_F1 0x000B
+#define SCAN_F2 0x000C
+#define SCAN_F3 0x000D
+#define SCAN_F4 0x000E
+#define SCAN_F5 0x000F
+#define SCAN_F6 0x0010
+#define SCAN_F7 0x0011
+#define SCAN_F8 0x0012
+#define SCAN_F9 0x0013
+#define SCAN_F10 0x0014
+#define SCAN_F11 0x0015
+#define SCAN_F12 0x0016
+#define SCAN_ESC 0x0017
+
+#define EFI_SIMPLE_TEXT_INPUT_PROTOCOL_GUID                                            \
+    {                                                                                  \
+        0x387477c1, 0x69c7, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } \
+    }
+
+struct _EFI_SIMPLE_TEXT_INPUT;
+
+#define DEF_TEXTI_EFI_FUNC(name, ...) typedef EFIStatus (*EFI_TEXTI_##name)(struct _EFI_SIMPLE_TEXT_INPUT * self __VA_OPT__(, ) __VA_ARGS__)
+
+typedef struct
+{
+    u16 scan_code;
+    u16 unicode_char;
+} EFIInputKey;
+
+DEF_TEXTI_EFI_FUNC(RESET, bool);
+DEF_TEXTI_EFI_FUNC(READ_KEY, EFIInputKey *key);
+
+typedef struct _EFI_SIMPLE_TEXT_INPUT
+{
+    EFI_TEXTI_RESET reset;
+    EFI_TEXTI_READ_KEY read_key;
+    EFIEvent wait_for_key;
+} EFISimpleTextInput;

--- a/sources/libs/efi/dpp.h
+++ b/sources/libs/efi/dpp.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <efi/base.h>
+
+#define EFI_DEVICE_PATH_PROTOCOL_GUID                                                  \
+    {                                                                                  \
+        0x09576e91, 0x6d3f, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } \
+    }
+
+#define EFI_HARDWARE_DEVICE_PATH 0x01
+#define EFI_ACPI_DEVICE_PATH 0x02
+#define EFI_MESSAGING_DEVICE_PATH 0x03
+#define EFI_MEDIA_DEVICE_PATH 0x04
+#define EFI_BIOS_BOOT_SPECIFICATION_DEVICE_PATH 0x05
+#define EFI_END_OF_HARDWARE_DEVICE_PATH 0x7f
+
+typedef struct
+{
+    u8 type;
+    u8 sub_type;
+    u8 length[2];
+} EFIDevicePath;

--- a/sources/libs/efi/file.h
+++ b/sources/libs/efi/file.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <efi/base.h>
+#include <efi/dpp.h>
+
+#define EFI_FILE_INFO_ID                                                               \
+    {                                                                                  \
+        0x09576e92, 0x6d3f, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } \
+    }
+#define EFI_FILE_SYSTEM_INFO_ID                                                        \
+    {                                                                                  \
+        0x09576e93, 0x6d3f, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } \
+    }
+#define EFI_FILE_SYSTEM_VOLUME_LABEL_ID                                                \
+    {                                                                                  \
+        0xdb47d7d3, 0xfe81, 0x11d3, { 0x9a, 0x35, 0x00, 0x90, 0x27, 0x3f, 0xc1, 0x4d } \
+    }
+
+#define EFI_FILE_PROTOCOL_REVISION 0x00010000
+#define EFI_FILE_PROTOCOL_REVISION2 0x00020000
+#define EFI_FILE_PROTOCOL_LATEST_REVISION EFI_FILE_PROTOCOL_REVISION2
+
+#define EFI_FILE_MODE_READ 0x0000000000000001
+#define EFI_FILE_MODE_WRITE 0x0000000000000002
+#define EFI_FILE_MODE_CREATE 0x8000000000000000
+
+#define EFI_FILE_READ_ONLY 0x0000000000000001
+#define EFI_FILE_HIDDEN 0x0000000000000002
+#define EFI_FILE_SYSTEM 0x0000000000000004
+#define EFI_FILE_RESERVED 0x0000000000000008
+#define EFI_FILE_DIRECTORY 0x0000000000000010
+#define EFI_FILE_ARCHIVE 0x0000000000000020
+#define EFI_FILE_VALID_ATTR 0x0000000000000037
+
+typedef struct EFI_FILE_INFO
+{
+    u64 size;
+    u64 file_size;
+    u64 physical_size;
+    EFITime create_time;
+    EFITime last_access_time;
+    EFITime modification_time;
+    u64 attribute;
+    char16 file_name[256];
+} EFIFileInfo;
+
+typedef struct EFI_FILE_SYSTEM_INFO
+{
+    u64 size;
+    bool read_only;
+    u64 volume_size;
+    u64 free_space;
+    u32 block_size;
+    char16 volume_label;
+} EFIFileSystemInfo;
+
+typedef struct
+{
+    char16 volume_label[256];
+} EFIFileSystemVolumeLabel;
+
+typedef struct
+{
+    EFIEvent event;
+    EFIStatus status;
+    u32 buffer_size;
+    void *buffer;
+} EFIFileIOToken;
+
+struct _EFI_FILE_IO;
+
+#define DEF_FILE_EFI_FUNC(name, ...) typedef EFIStatus (*EFI_FILE_##name)(struct _EFI_FILE_IO * self __VA_OPT__(, ) __VA_ARGS__)
+
+DEF_FILE_EFI_FUNC(OPEN, struct _EFI_FILE_IO **, char16 *, u64, u64);
+DEF_FILE_EFI_FUNC(CLOSE);
+DEF_FILE_EFI_FUNC(DELETE);
+DEF_FILE_EFI_FUNC(READ, u64*, void *);
+DEF_FILE_EFI_FUNC(WRITE, u8, void *);
+DEF_FILE_EFI_FUNC(GET_POSITION, u64 *);
+DEF_FILE_EFI_FUNC(SET_POSITION, u64);
+DEF_FILE_EFI_FUNC(GET_INFO, EFIGUID *, u64 *, void *);
+DEF_FILE_EFI_FUNC(SET_INFO, EFIGUID *, u64, void *);
+DEF_FILE_EFI_FUNC(FLUSH);
+DEF_FILE_EFI_FUNC(OPEN_EX, struct _EFI_FILE_IO **, char16 *, u64, u64, EFIFileIOToken *);
+DEF_FILE_EFI_FUNC(READ_EX, EFIFileIOToken *);
+DEF_FILE_EFI_FUNC(WRITE_EX, EFIFileIOToken *);
+DEF_FILE_EFI_FUNC(FLUSH_EX, EFIFileIOToken *);
+
+typedef struct _EFI_FILE_IO
+{
+    u64 revision;
+    EFI_FILE_OPEN open;
+    EFI_FILE_CLOSE close;
+    EFI_FILE_DELETE delete;
+    EFI_FILE_READ read;
+    EFI_FILE_WRITE write;
+    EFI_FILE_GET_POSITION get_position;
+    EFI_FILE_SET_POSITION set_position;
+    EFI_FILE_GET_INFO get_info;
+    EFI_FILE_SET_INFO set_info;
+    EFI_FILE_FLUSH flush;
+    EFI_FILE_OPEN_EX open_ex;
+    EFI_FILE_READ_EX read_ex;
+    EFI_FILE_WRITE_EX write_ex;
+    EFI_FILE_FLUSH_EX flush_ex;
+} EFIFileProtocol;

--- a/sources/libs/efi/lip.h
+++ b/sources/libs/efi/lip.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <efi/base.h>
+#include <efi/st.h>
+
+#define EFI_LOADED_IMAGE_PROTOCOL_GUID                                                 \
+    {                                                                                  \
+        0x5b1b31a1, 0x9562, 0x11d2, { 0x8e, 0x3f, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } \
+    }
+
+#define EFI_LOADED_IMAGE_PROTOCOL_REVISION 0x1000
+
+typedef EFIStatus (*EFI_IMAGE_UNLOAD)(EFIHandle);
+
+typedef struct EFI_LOADED_IMAGE_PROTOCOL
+{
+    u32 revision;
+    EFIHandle parent_handle;
+    EFISystemTable *system_table;
+    EFIHandle device_handle;
+    EFIDevicePath *file_path;
+    void *reserved;
+    u32 load_options_size;
+    void *load_options;
+    void *image_base;
+    u64 image_size;
+    u64 image_code_type;
+    EFI_IMAGE_UNLOAD unload;
+} EFILoadedImage;

--- a/sources/libs/efi/misc.c
+++ b/sources/libs/efi/misc.c
@@ -1,0 +1,523 @@
+#include "misc.h"
+#include <stdbool.h>
+
+enum format_type_width
+{
+    FMT_TYPE_CHAR,
+    FMT_TYPE_SHORT,
+    FMT_TYPE_INT,
+    FMT_TYPE_LONG,
+    FMT_TYPE_LONG_LONG,
+    FMT_TYPE_SIZE,
+    FMT_TYPE_PTRDIFF,
+    FMT_TYPE_NONE,
+};
+
+enum format_type
+{
+    FMT_SCHAR,
+    FMT_SHORT_INT,
+    FMT_INT,
+    FMT_LONG_INT,
+    FMT_LONG_LONG_INT,
+    FMT_UCHAR,
+    FMT_SHORT_UINT,
+    FMT_UINT,
+    FMT_LONG_UINT,
+    FMT_LONG_LONG_UINT,
+    FMT_SIZE,
+    FMT_PTR,
+    FMT_PTRDIFF,
+    FMT_STR,
+    FMT_UEFI_STR,
+    FMT_PERCENT,
+    FMT_CHAR,
+    FMT_NONE,
+};
+
+const unsigned FMT_FLAG_MINUS = 1;
+const unsigned FMT_FLAG_PLUS = 2;
+const unsigned FMT_FLAG_SPACE = 4;
+const unsigned FMT_FLAG_BASE = 8;
+const unsigned FMT_FLAG_ZERO = 16;
+
+struct format
+{
+    unsigned flags;
+    bool width_from_args;
+    unsigned width;
+    enum format_type_width type_width;
+    enum format_type type;
+    unsigned base;
+    size_t size;
+};
+
+struct format_buffer
+{
+    uint16_t *buffer;
+    size_t size;
+    size_t count;
+};
+
+static void buffer_append(struct format_buffer *buffer, int code)
+{
+    if (buffer->count < buffer->size)
+        buffer->buffer[buffer->count] = code;
+    ++buffer->count;
+}
+
+static void buffer_copy_u16(
+    struct format_buffer *buffer, const uint16_t *begin, const uint16_t *end)
+{
+    const size_t len = end - begin;
+    const size_t rem =
+        buffer->count < buffer->size
+            ? buffer->size - buffer->count
+            : 0;
+    const size_t copy = len < rem ? len : rem;
+    uint16_t *pos = buffer->buffer + buffer->count;
+
+    for (size_t i = 0; i < copy; ++i)
+        *pos++ = begin[i];
+    buffer->count += len;
+}
+
+static void buffer_copy(
+    struct format_buffer *buffer, const char *begin, const char *end)
+{
+    const size_t len = end - begin;
+    const size_t rem =
+        buffer->count < buffer->size
+            ? buffer->size - buffer->count
+            : 0;
+    const size_t copy = len < rem ? len : rem;
+    uint16_t *pos = buffer->buffer + buffer->count;
+
+    for (size_t i = 0; i < copy; ++i)
+        *pos++ = begin[i];
+    buffer->count += len;
+}
+
+static void buffer_format_unsigned(
+    struct format_buffer *buffer, struct format *config, unsigned long long v)
+{
+    char buf[32];
+    char *pos = buf;
+
+    do
+    {
+        const unsigned d = v % config->base;
+
+        v = v / config->base;
+        if (d < 10)
+            *pos = d + '0';
+        else
+            *pos = d - 10 + 'A';
+        ++pos;
+    } while (v);
+
+    for (char *l = buf, *r = pos - 1; l < r; ++l, --r)
+    {
+        const char c = *l;
+
+        *l = *r;
+        *r = c;
+    }
+
+    buffer_copy(buffer, buf, pos);
+}
+
+static void buffer_format_signed(
+    struct format_buffer *buffer, struct format *config, long long v)
+{
+    if (v < 0)
+    {
+        buffer_append(buffer, '-');
+        v = -v;
+    }
+    buffer_format_unsigned(buffer, config, v);
+}
+
+static const char *format_parse_flags(const char *str, struct format *config)
+{
+    while (*str)
+    {
+        bool is_flag = true;
+
+        switch (*str)
+        {
+        case '-':
+            config->flags = FMT_FLAG_MINUS;
+            break;
+        case '+':
+            config->flags = FMT_FLAG_PLUS;
+            break;
+        case ' ':
+            config->flags = FMT_FLAG_SPACE;
+            break;
+        case '#':
+            config->flags = FMT_FLAG_BASE;
+            break;
+        case '0':
+            config->flags = FMT_FLAG_ZERO;
+            break;
+        default:
+            is_flag = false;
+            break;
+        }
+
+        if (!is_flag)
+            break;
+        ++str;
+    }
+    return str;
+}
+
+static const char *format_parse_width(const char *str, struct format *config)
+{
+    if (*str == '*')
+    {
+        config->width_from_args = true;
+        return str + 1;
+    }
+
+    while (isdigit(*str))
+    {
+        config->width = config->width * 10 + (*str - '0');
+        ++str;
+    }
+
+    return str;
+}
+
+static const char *format_parse_type_width(const char *str, struct format *config)
+{
+    if (*str == 'z')
+    {
+        config->type_width = FMT_TYPE_SIZE;
+        return str + 1;
+    }
+
+    if (*str == 't')
+    {
+        config->type_width = FMT_TYPE_PTRDIFF;
+        return str + 1;
+    }
+
+    if (*str == 'h')
+    {
+        ++str;
+        if (*str == 'h')
+        {
+            config->type_width = FMT_TYPE_CHAR;
+            return str + 1;
+        }
+        config->type_width = FMT_TYPE_SHORT;
+        return str;
+    }
+
+    if (*str == 'l')
+    {
+        ++str;
+        if (*str == 'l')
+        {
+            config->type_width = FMT_TYPE_LONG_LONG;
+            return str + 1;
+        }
+        config->type_width = FMT_TYPE_LONG;
+        return str;
+    }
+
+    return str;
+}
+
+static enum format_type format_adjusted_type(enum format_type type, enum format_type_width width)
+{
+    if (type == FMT_INT)
+    {
+        switch (width)
+        {
+        case FMT_TYPE_CHAR:
+            return FMT_SCHAR;
+        case FMT_TYPE_SHORT:
+            return FMT_SHORT_INT;
+        case FMT_TYPE_LONG:
+            return FMT_LONG_INT;
+        case FMT_TYPE_LONG_LONG:
+            return FMT_LONG_LONG_INT;
+        case FMT_TYPE_SIZE:
+            return FMT_SIZE;
+        case FMT_TYPE_PTRDIFF:
+            return FMT_PTRDIFF;
+        default:
+            return type;
+        }
+    }
+
+    if (type == FMT_UINT)
+    {
+        switch (width)
+        {
+        case FMT_TYPE_CHAR:
+            return FMT_UCHAR;
+        case FMT_TYPE_SHORT:
+            return FMT_SHORT_UINT;
+        case FMT_TYPE_LONG:
+            return FMT_LONG_UINT;
+        case FMT_TYPE_LONG_LONG:
+            return FMT_LONG_LONG_UINT;
+        case FMT_TYPE_SIZE:
+            return FMT_SIZE;
+        case FMT_TYPE_PTRDIFF:
+            return FMT_PTRDIFF;
+        default:
+            return type;
+        }
+    }
+
+    return type;
+}
+
+static const char *format_parse_spec(const char *str, struct format *config)
+{
+    const char *pos = str;
+
+    if (*pos == '%')
+    {
+        config->type = FMT_PERCENT;
+        return pos + 1;
+    }
+
+    pos = format_parse_type_width(pos, config);
+
+    switch (*pos)
+    {
+    case 'd':
+    case 'i':
+    case 'u':
+        config->base = 10;
+        break;
+    case 'o':
+        config->base = 8;
+        break;
+    case 'x':
+    case 'X':
+    case 'p':
+        config->base = 16;
+        break;
+    }
+
+    switch (*pos)
+    {
+    case 'd':
+    case 'i':
+        config->type = format_adjusted_type(FMT_INT, config->type_width);
+        break;
+    case 'u':
+    case 'o':
+    case 'x':
+    case 'X':
+        config->type = format_adjusted_type(FMT_UINT, config->type_width);
+        break;
+    case 'c':
+        config->type = FMT_CHAR;
+        break;
+    case 's':
+        config->type = FMT_STR;
+        break;
+    case 'w':
+        config->type = FMT_UEFI_STR;
+        break;
+    case 'p':
+        config->type = FMT_PTR;
+        break;
+    default:
+        return str;
+    }
+
+    return pos + 1;
+}
+
+static int format_parse(const char *str, struct format *config)
+{
+    const char *pos = str;
+    const char *end;
+
+    config->flags = 0;
+    config->width_from_args = false;
+    config->width = 0;
+    config->type_width = FMT_TYPE_NONE;
+    config->type = FMT_NONE;
+    config->base = 0;
+    config->size = 0;
+
+    pos = format_parse_flags(pos, config);
+    pos = format_parse_width(pos, config);
+
+    // The spec is the only mandatory part, so if it's empty it's a problem
+    end = format_parse_spec(pos, config);
+    if (pos == end)
+        return -1;
+    config->size = end - str;
+
+    return 0;
+}
+
+int u16vsnprintf(uint16_t *buffer, size_t size, const char *fmt, va_list args)
+{
+    struct format_buffer buf = {buffer, size - 1, 0};
+    const char *current = fmt;
+
+    while (*current)
+    {
+        const char *start = current;
+        const char *end = current;
+
+        struct format config;
+        unsigned long long uv;
+        long long v;
+        int ret;
+
+        while (*end && *end != '%')
+            ++end;
+
+        buffer_copy(&buf, start, end);
+        if (*end == '\0')
+        {
+            current = end;
+            break;
+        }
+
+        ret = format_parse(end + 1, &config);
+        if (ret < 0)
+            return ret;
+        current = end + 1 + config.size;
+
+        if (config.width_from_args)
+            config.width = (unsigned)va_arg(args, int);
+
+        switch (config.type)
+        {
+        case FMT_STR:
+        {
+            const char *str = va_arg(args, const char *);
+            buffer_copy(&buf, str, str + strlen(str));
+            break;
+        }
+        case FMT_UEFI_STR:
+        {
+            const uint16_t *str = va_arg(args, const uint16_t *);
+            buffer_copy_u16(&buf, str, str + u16strlen(str));
+            break;
+        }
+        case FMT_CHAR:
+        {
+            int v = va_arg(args, int);
+            buffer_append(&buf, v);
+            break;
+        }
+        case FMT_PERCENT:
+            buffer_append(&buf, u'%');
+            break;
+        case FMT_SCHAR:
+        case FMT_SHORT_INT:
+        case FMT_INT:
+            v = va_arg(args, int);
+            buffer_format_signed(&buf, &config, v);
+            break;
+        case FMT_LONG_INT:
+            v = va_arg(args, long);
+            buffer_format_signed(&buf, &config, v);
+            break;
+        case FMT_LONG_LONG_INT:
+            v = va_arg(args, long long);
+            buffer_format_signed(&buf, &config, v);
+            break;
+        case FMT_PTRDIFF:
+            v = (long long)va_arg(args, ptrdiff_t);
+            buffer_format_unsigned(&buf, &config, v);
+            break;
+        case FMT_UCHAR:
+        case FMT_SHORT_UINT:
+        case FMT_UINT:
+            uv = va_arg(args, unsigned);
+            buffer_format_unsigned(&buf, &config, uv);
+            break;
+        case FMT_LONG_UINT:
+            uv = va_arg(args, unsigned long);
+            buffer_format_unsigned(&buf, &config, uv);
+            break;
+        case FMT_LONG_LONG_UINT:
+            uv = va_arg(args, unsigned long long);
+            buffer_format_unsigned(&buf, &config, uv);
+            break;
+        case FMT_SIZE:
+            uv = va_arg(args, size_t);
+            buffer_format_unsigned(&buf, &config, uv);
+            break;
+        case FMT_PTR:
+            uv = (unsigned long long)va_arg(args, void *);
+            buffer_format_unsigned(&buf, &config, uv);
+            break;
+        default:
+            return -1;
+        }
+    }
+
+    if (buf.count < buf.size)
+        buf.buffer[buf.count] = u'\0';
+    else
+        buf.buffer[buf.size] = u'\0';
+
+    return (int)buf.count;
+}
+
+int u16snprintf(uint16_t *buffer, size_t size, const char *fmt, ...)
+{
+    va_list args;
+    int ret;
+
+    va_start(args, fmt);
+    ret = u16vsnprintf(buffer, size, fmt, args);
+    va_end(args);
+    return ret;
+}
+
+size_t u16strlen(const uint16_t *str)
+{
+    const uint16_t *pos = str;
+
+    while (*pos++)
+        ;
+    return pos - str - 1;
+}
+
+int u16strcmp(const uint16_t *l, const uint16_t *r)
+{
+    while (*l == *r && *l != '\0')
+    {
+        ++l;
+        ++r;
+    }
+
+    if (*l == *r)
+        return 0;
+
+    if (*l < *r)
+        return -1;
+    else
+        return 1;
+}
+
+uint16_t *to_u16strncpy(uint16_t *dst, const char *src, size_t size)
+{
+    size_t i = 0;
+
+    for (; i < size && src[i]; ++i)
+        dst[i] = src[i];
+
+    for (; i < size; ++i)
+        dst[i] = '\0';
+
+    return dst;
+}

--- a/sources/libs/efi/misc.h
+++ b/sources/libs/efi/misc.h
@@ -1,5 +1,4 @@
-#ifndef __CLIB_H__
-#define __CLIB_H__
+#pragma once
 
 #include <ctype.h>
 #include <stdarg.h>
@@ -13,5 +12,3 @@ int u16vsnprintf(uint16_t *buffer, size_t size, const char *fmt, va_list args);
 int u16snprintf(uint16_t *buffer, size_t size, const char *fmt, ...);
 size_t u16strlen(const uint16_t *str);
 uint16_t *to_u16strncpy(uint16_t *dst, const char *src, size_t size);
-
-#endif // __CLIB_H__

--- a/sources/libs/efi/misc.h
+++ b/sources/libs/efi/misc.h
@@ -1,0 +1,17 @@
+#ifndef __CLIB_H__
+#define __CLIB_H__
+
+#include <ctype.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+int u16strcmp(const uint16_t *l, const uint16_t *r);
+
+int u16vsnprintf(uint16_t *buffer, size_t size, const char *fmt, va_list args);
+int u16snprintf(uint16_t *buffer, size_t size, const char *fmt, ...);
+size_t u16strlen(const uint16_t *str);
+uint16_t *to_u16strncpy(uint16_t *dst, const char *src, size_t size);
+
+#endif // __CLIB_H__

--- a/sources/libs/efi/rs.h
+++ b/sources/libs/efi/rs.h
@@ -1,0 +1,70 @@
+#pragma once
+#include <efi/base.h>
+#include <efi/bs.h>
+
+#define EFI_OPTIONAL_POINTER 0x00000001
+
+#define CAPSULE_FLAGS_PERSIST_ACROSS_RESET 0x00010000
+#define CAPSULE_FLAGS_POPULATE_SYSTEM_TABLE 0x00020000
+#define CAPSULE_FLAGS_INITIATE_RESET 0x00040000
+
+typedef enum
+{
+    EFI_RESET_COLD,
+    EFI_RESET_WARM,
+    EFI_RESET_SHUTDOWN,
+    EFI_RESET_PLATFORM_SPECIFIC
+} EFIResetType;
+
+typedef struct
+{
+    u64 length;
+    union
+    {
+        u64 data_block;
+        u64 continuation_pointer;
+    } _union;
+
+} EFICapsuleBlockDescriptor;
+
+typedef struct
+{
+    EFIGUID capsule_guid;
+    u32 header_size;
+    u32 flags;
+    u32 capsule_image_size;
+} EFICapsuleHeader;
+
+DEF_EFI_FUNC(GET_TIME, EFITime *, EFITimeCapabilities *);
+DEF_EFI_FUNC(SET_TIME, EFITime *);
+DEF_EFI_FUNC(GET_WAKEUP_TIME, bool *, bool *, EFITime *);
+DEF_EFI_FUNC(SET_WAKEUP_TIME, bool, EFITime *);
+DEF_EFI_FUNC(SET_VIRTUAL_ADDRESS_MAP, u64, u64, u32, EFIMemoryDescriptor *);
+DEF_EFI_FUNC(CONVERT_POINTER, u64, void **);
+DEF_EFI_FUNC(GET_VARIABLE, char16 *, EFIGUID *, u32 *, u64 *, void *);
+DEF_EFI_FUNC(GET_NEXT_VARIABLE_NAME, u64, char16 *, EFIGUID *);
+DEF_EFI_FUNC(SET_VARIABLE, char16 *, EFIGUID *, u32, u64, void *);
+DEF_EFI_FUNC(GET_NEXT_HIGH_MONO_COUNT, u32 *);
+DEF_EFI_FUNC(RESET_SYSTEM, EFIResetType, EFIStatus, u64, void *);
+DEF_EFI_FUNC(UPDATE_CAPSULE, EFICapsuleHeader **, u64, u64);
+DEF_EFI_FUNC(QUERY_CAPSULE_CAPABILITIES, EFICapsuleHeader **, u64, u64 *, EFIResetType *);
+DEF_EFI_FUNC(QUERY_VARIABLE_INFO, u32, u64 *, u64 *, u64 *);
+
+typedef struct
+{
+    EFITableHeader hdr;
+    EFI_GET_TIME get_time;
+    EFI_SET_TIME set_time;
+    EFI_GET_WAKEUP_TIME get_wakeup_time;
+    EFI_SET_WAKEUP_TIME set_wakeup_time;
+    EFI_SET_VIRTUAL_ADDRESS_MAP set_virtual_address_map;
+    EFI_CONVERT_POINTER convert_pointer;
+    EFI_GET_VARIABLE get_variable;
+    EFI_GET_NEXT_VARIABLE_NAME get_next_variable_name;
+    EFI_SET_VARIABLE set_variable;
+    EFI_GET_NEXT_HIGH_MONO_COUNT get_next_high_monotonic_count;
+    EFI_RESET_SYSTEM reset_system;
+    EFI_UPDATE_CAPSULE update_capsule;
+    EFI_QUERY_CAPSULE_CAPABILITIES query_capsule_capabilities;
+    EFI_QUERY_VARIABLE_INFO query_variable_info;
+} EFIRuntimeServices;

--- a/sources/libs/efi/sfsp.h
+++ b/sources/libs/efi/sfsp.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <efi/base.h>
+#include <efi/file.h>
+
+#define EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_REVISION 0x00010000
+
+#define EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_GUID                                            \
+    {                                                                                   \
+        0x0964e5b22, 0x6459, 0x11d2, { 0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b } \
+    }
+
+struct EFI_SIMPLE_FILE_SYSTEM_PROTOCOL;
+
+typedef EFIStatus (*EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_OPEN_VOLUME)(struct EFI_SIMPLE_FILE_SYSTEM_PROTOCOL*, EFIFileProtocol **Root);
+
+typedef struct EFI_SIMPLE_FILE_SYSTEM_PROTOCOL
+{
+    u64 revision;
+    EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_OPEN_VOLUME open_volume;
+} EFISimpleFileSystemProtocol;

--- a/sources/libs/efi/st.h
+++ b/sources/libs/efi/st.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <efi/base.h>
+#include <efi/bs.h>
+#include <efi/console.h>
+#include <efi/rs.h>
+
+typedef struct
+{
+    char a[36];
+    EFIHandle console_in_handle;
+    EFISimpleTextInput *console_in;
+    EFIHandle console_out_handle;
+    EFISimpleTextOutput *console_out;
+    char b[16];
+    EFIRuntimeServices *runtime_services;
+    EFIBootServices *boot_services;
+} EFISystemTable;

--- a/sources/libs/efi/utils.c
+++ b/sources/libs/efi/utils.c
@@ -1,7 +1,6 @@
 #include "utils.h"
 #include <brutal/alloc.h>
 #include <brutal/host/mem.h>
-#include <stdatomic.h>
 #include "brutal/base/error.h"
 #include "efi/file.h"
 #include "efi/lip.h"

--- a/sources/libs/efi/utils.c
+++ b/sources/libs/efi/utils.c
@@ -1,8 +1,8 @@
 #include "utils.h"
-#include "misc.h"
 #include "efi/file.h"
 #include "efi/lip.h"
 #include "efi/st.h"
+#include "misc.h"
 
 EFISystemTable *st;
 EFIHandle image_handle;
@@ -121,6 +121,19 @@ void *efi_malloc(u64 size)
 
     void *ptr;
     st->boot_services->allocate_pool(EFI_BOOT_SERVICES_DATA, page_count, &ptr);
+
+    return ptr;
+}
+
+void *to_utf16(void *ptr, char *buffer)
+{
+    ptr = efi_malloc(strlen(buffer) << 1);
+
+    memset(ptr, 0, sizeof(ptr));
+    for (size_t i = 0; i < sizeof(buffer) / sizeof(*buffer); i++)
+    {
+        *(char16 *)(ptr + (i << 1)) = buffer[i];
+    }
 
     return ptr;
 }

--- a/sources/libs/efi/utils.c
+++ b/sources/libs/efi/utils.c
@@ -1,6 +1,7 @@
 #include "utils.h"
 #include <brutal/alloc.h>
 #include <brutal/host/mem.h>
+#include <stdatomic.h>
 #include "brutal/base/error.h"
 #include "efi/file.h"
 #include "efi/lip.h"
@@ -147,10 +148,11 @@ void host_mem_unlock(void)
 
 void *to_utf16(void *ptr, char *buffer)
 {
-    ptr = efi_malloc(strlen(buffer) << 1);
+    ptr = alloc_acquire(alloc_global(), strlen(buffer) << 1);
 
     memset(ptr, 0, sizeof(ptr));
-    for (size_t i = 0; i < sizeof(buffer) / sizeof(*buffer); i++)
+    
+    for (size_t i = 0; i < strlen(buffer); i++)
     {
         *(char16 *)(ptr + (i << 1)) = buffer[i];
     }

--- a/sources/libs/efi/utils.c
+++ b/sources/libs/efi/utils.c
@@ -1,0 +1,131 @@
+#include "utils.h"
+#include "misc.h"
+#include "efi/file.h"
+#include "efi/lip.h"
+#include "efi/st.h"
+
+EFISystemTable *st;
+EFIHandle image_handle;
+
+static EFIFileProtocol *rootdir;
+static EFISimpleFileSystemProtocol *rootfs;
+
+static File current_file;
+
+void init_lib(EFISystemTable *st2, EFIHandle image_handle2)
+{
+    st = st2;
+    image_handle = image_handle2;
+}
+
+static EFIStatus get_rootdir(EFISimpleFileSystemProtocol *rootfs, EFIFileProtocol **rootdir)
+{
+    return rootfs->open_volume(rootfs, rootdir);
+}
+
+static EFIStatus get_rootfs(EFIHandle loader, EFISystemTable *system, EFIHandle device, EFISimpleFileSystemProtocol **rootfs)
+{
+    EFIGUID guid = EFI_SIMPLE_FILE_SYSTEM_PROTOCOL_GUID;
+
+    return system->boot_services->open_protocol(
+        device,
+        &guid,
+        (void **)rootfs,
+        loader,
+        NULL,
+        EFI_OPEN_PROTOCOL_BY_HANDLE_PROTOCOL);
+}
+
+static EFIStatus get_loader_image(EFIHandle loader, EFISystemTable *system, EFILoadedImage **image)
+{
+    EFIGUID guid = EFI_LOADED_IMAGE_PROTOCOL_GUID;
+
+    return system->boot_services->open_protocol(
+        loader,
+        &guid,
+        (void **)image,
+        loader,
+        NULL,
+        EFI_OPEN_PROTOCOL_BY_HANDLE_PROTOCOL);
+}
+
+File open_file(u16 *path)
+{
+    File f;
+
+    f.status = 0;
+
+    EFILoadedImage *image;
+
+    get_loader_image(image_handle, st, &image);
+    get_rootfs(image_handle, st, image->device_handle, &rootfs);
+    get_rootdir(rootfs, &rootdir);
+
+    /* Open the file as readonly */
+    f.status = rootdir->open(rootdir, &f.efi_file, path, EFI_FILE_MODE_READ, EFI_FILE_READ_ONLY);
+
+    current_file = f;
+
+    return f;
+}
+
+EFIFileInfo get_file_info(File *file)
+{
+
+    EFIGUID guid = EFI_FILE_INFO_ID;
+    u64 info_size = sizeof(file->info);
+
+    file->efi_file->get_info(file->efi_file, &guid, &info_size, &file->info);
+
+    return file->info;
+}
+
+void read_file(File *file, void *buffer)
+{
+
+    u64 file_size = file->info.file_size;
+
+    file->buffer = buffer;
+
+    file->status = file->efi_file->read(file->efi_file, &file_size, buffer);
+}
+
+void close_file(File *file)
+{
+
+    file->status = rootdir->close(file->efi_file);
+}
+
+void efi_printf(char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    u16 buffer[1024];
+
+    u16vsnprintf(buffer, sizeof(buffer), fmt, args);
+    st->console_out->output_string(st->console_out, buffer);
+
+    va_end(args);
+}
+
+#define DIV_ROUNDUP(A, B) (      \
+    {                            \
+        __typeof__(A) _a_ = A;   \
+        __typeof__(B) _b_ = B;   \
+        (_a_ + (_b_ - 1)) / _b_; \
+    })
+
+void *efi_malloc(u64 size)
+{
+    size_t page_count = DIV_ROUNDUP(size, 4096);
+
+    void *ptr;
+    st->boot_services->allocate_pool(EFI_BOOT_SERVICES_DATA, page_count, &ptr);
+
+    return ptr;
+}
+
+void efi_free(void *ptr)
+{
+    st->boot_services->free_pool(ptr);
+}

--- a/sources/libs/efi/utils.h
+++ b/sources/libs/efi/utils.h
@@ -23,5 +23,4 @@ EFIFileInfo get_file_info(File *file);
 void efi_printf(char *fmt, ...);
 void *efi_malloc(u64 size);
 void efi_free(void *ptr);
-
 void *to_utf16(void* ptr, char *buffer);

--- a/sources/libs/efi/utils.h
+++ b/sources/libs/efi/utils.h
@@ -24,10 +24,4 @@ void efi_printf(char *fmt, ...);
 void *efi_malloc(u64 size);
 void efi_free(void *ptr);
 
-#define TO_UTF16(ptr, buffer)                                     \
-    void *ptr = efi_malloc(strlen(buffer) << 1);                 \
-    memset(ptr, 0, sizeof(ptr));                                 \
-    for (size_t i = 0; i < sizeof(buffer) / sizeof(*buffer); i++) \
-    {                                                             \
-        *(char16 *)(ptr + (i << 1)) = buffer[i];                  \
-    }
+void *to_utf16(void* ptr, char *buffer);

--- a/sources/libs/efi/utils.h
+++ b/sources/libs/efi/utils.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <brutal/base.h>
+#include <efi/base.h>
+#include <efi/file.h>
+#include <efi/lip.h>
+#include <efi/sfsp.h>
+#include <efi/st.h>
+#include <string.h>
+
+typedef struct
+{
+    EFIFileInfo info;
+    EFIFileProtocol *efi_file;
+    void *buffer;
+    EFIStatus status;
+} File;
+
+void init_lib(EFISystemTable *st, EFIHandle image_handle);
+void read_file(File *file, void *buffer);
+File open_file(u16 *path);
+void close_file(File *file);
+EFIFileInfo get_file_info(File *file);
+void efi_printf(char *fmt, ...);
+void *efi_malloc(u64 size);
+void efi_free(void *ptr);
+
+#define TO_UTF16(ptr, buffer)                                     \
+    void *ptr = efi_malloc(strlen(buffer) << 1);                 \
+    memset(ptr, 0, sizeof(ptr));                                 \
+    for (size_t i = 0; i < sizeof(buffer) / sizeof(*buffer); i++) \
+    {                                                             \
+        *(char16 *)(ptr + (i << 1)) = buffer[i];                  \
+    }

--- a/sources/libs/efi/utils.h
+++ b/sources/libs/efi/utils.h
@@ -21,6 +21,4 @@ File open_file(u16 *path);
 void close_file(File *file);
 EFIFileInfo get_file_info(File *file);
 void efi_printf(char *fmt, ...);
-void *efi_malloc(u64 size);
-void efi_free(void *ptr);
-void *to_utf16(void* ptr, char *buffer);
+void *to_utf16(void *ptr, char *buffer);


### PR DESCRIPTION
I added a basic EFI library for the work-in-progress bootloader.

I am using my own printf-like thing because for a certain reason, fmt wouldn't want to work with utf16.
I also implemented my own `strncpy` since yours is broken (add a '\0' at the end of the string).