### PR TITLE
Fix: replace \e by \033 in the makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ T := $(shell $(MAKE) $(MAKECMDGOALS) --no-print-directory \
 N := x
 C = $(words $N)$(eval N := x $N)
 
-ECHO = @echo -e "`printf "\e[1m %3d%%\e[m" $$(expr $C '*' 100 / $T)`"
+ECHO = @echo -e "`printf "\033[1m %3d%%\033[m" $$(expr $C '*' 100 / $T)`"
 endif
 
 CFLAGS_STD ?= \

--- a/sources/bins/.cross.mk
+++ b/sources/bins/.cross.mk
@@ -29,17 +29,17 @@ LIBS_BIN=$(BUILDDIR_CROSS)/libbrutal.a
 DEPENDENCIES += $(LIBS_OBJ:.o=.d)
 
 $(BUILDDIR_CROSS)/%.c.o: sources/%.c
-	$(ECHO) "\e[37mbrutal \e[92mCC\e[m" $<
+	$(ECHO) "\033[37mbrutal \033[92mCC\033[m" $<
 	@$(MKCWD)
 	@$(CROSS_CC) -c -o $@ $< $(CROSS_UCFLAGS)
 
 $(BUILDDIR_CROSS)/%.s.o: sources/%.s
-	$(ECHO) "\e[37mbrutal \e[92mAS\e[m" $<
+	$(ECHO) "\033[37mbrutal \033[92mAS\033[m" $<
 	@$(MKCWD)
 	@$(CROSS_AS) -o $@ $^ $(CROSS_ASFLAGS)
 
 $(LIBS_BIN): $(LIBS_OBJ)
-	$(ECHO) "\e[37mbrutal \e[92mAR\e[m" $@
+	$(ECHO) "\033[37mbrutal \033[92mAR\033[m" $@
 	@$(MKCWD)
 	@$(CROSS_AR) $(CROSS_ARFLAGS) $@ $^
 
@@ -56,7 +56,7 @@ DEPENDENCIES += $$($(1)_OBJ:.o=.d)
 SERVERS+=$$($(1)_BIN)
 
 $$($(1)_BIN): $$($(1)_OBJ) $(LIBS_BIN)
-	$$(ECHO) "\e[37mbrutal \e[92mLD\e[m" $$@
+	$$(ECHO) "\033[37mbrutal \033[92mLD\033[m" $$@
 	@$$(MKCWD)
 	@$(CROSS_LD) -o $$@ $$^ $(CROSS_ULDFLAGS)
 

--- a/sources/bins/.host.mk
+++ b/sources/bins/.host.mk
@@ -20,17 +20,17 @@ LIBS_HOST_OBJ = \
 LIBS_HOST_BIN=$(BUILDDIR_HOST)/libbrutal.a
 
 $(BUILDDIR_HOST)/%.c.o: sources/%.c
-	$(ECHO) "\e[37mhost   \e[92mCC\e[m" $<
+	$(ECHO) "\033[37mhost   \033[92mCC\033[m" $<
 	@$(MKCWD)
 	@$(HOST_CC) -c -o $@ $^ $(HOST_CFLAGS)
 
 $(BUILDDIR_HOST)/%.s.o: sources/%.s
-	$(ECHO) "\e[37mhost   \e[92mAS\e[m" $<
+	$(ECHO) "\033[37mhost   \033[92mAS\033[m" $<
 	@$(MKCWD)
 	@$(CROSS_AS) -o $@ $^ $(CROSS_ASFLAGS)
 
 $(LIBS_HOST_BIN): $(LIBS_HOST_OBJ)
-	$(ECHO) "\e[37mhost   \e[92mAR\e[m" $@
+	$(ECHO) "\033[37mhost   \033[92mAR\033[m" $@
 	@$(MKCWD)
 	@$(HOST_AR) $(HOST_ARFLAGS) $@ $^
 
@@ -50,7 +50,7 @@ $(1)_HOST_BIN  = $(BUILDDIR_HOST)/$($(1)_NAME)
 DEPENDENCIES += $$($(1)_OBJ:.o=.d)
 
 $$($(1)_HOST_BIN): $$($(1)_HOST_OBJ) $(LIBS_HOST_BIN)
-	$$(ECHO) "\e[37mhost   \e[92mLD\e[m" $$@
+	$$(ECHO) "\033[37mhost   \033[92mLD\033[m" $$@
 	@$$(MKCWD)
 	$(HOST_CC) -o $$@ $$^ $(HOST_LDFLAGS) $(HOST_CFLAGS)
 

--- a/sources/kernel/.build.mk
+++ b/sources/kernel/.build.mk
@@ -33,16 +33,16 @@ KERNEL_OBJ= \
 DEPENDENCIES += $(KERNEL_OBJ:.o=.d)
 
 $(BUILDDIR_KERNEL)/%.c.o: sources/%.c
-	$(ECHO) "\e[37mkernel \e[92mCC\e[m" $<
+	$(ECHO) "\033[37mkernel \033[92mCC\033[m" $<
 	@$(MKCWD)
 	@$(CROSS_CC) -c -o $@ $< $(CROSS_KCFLAGS)
 
 $(BUILDDIR_KERNEL)/%.s.o: sources/%.s
-	$(ECHO) "\e[37mkernel \e[92mAS\e[m" $<
+	$(ECHO) "\033[37mkernel \033[92mAS\033[m" $<
 	@$(MKCWD)
 	@$(CROSS_AS) -o $@ $< $(CROSS_ASFLAGS)
 
 $(KERNEL): $(KERNEL_OBJ)
-	$(ECHO) "\e[37mkernel \e[92mLD\e[m" $@
+	$(ECHO) "\033[37mkernel \033[92mLD\033[m" $@
 	@$(MKCWD)
 	@$(CROSS_LD) -o $@ $^ $(CROSS_KLDFLAGS)

--- a/sources/libs/proto/.build.mk
+++ b/sources/libs/proto/.build.mk
@@ -6,7 +6,7 @@ PROT_BID_SRC = 	$(wildcard sources/libs/proto/*.bid) \
 PROT_BID_H = $(patsubst %.bid, %.h, $(PROT_BID_SRC))
 
 %.h: %.bid $(BID_HOST_BIN)
-	$(ECHO) "\e[37mhost   \e[92mBID\e[m" $@
+	$(ECHO) "\033[37mhost   \033[92mBID\033[m" $@
 	@$(MKCWD)
 	@$(BID_HOST_BIN) $< $@
 


### PR DESCRIPTION
In Makefile, \e or \x1b doesn't work. Only \033 works.﻿
