### PR TITLE
Fix unused / empty mmap entries

### DIFF
--- a/sources/kernel/x86_64/pmm.c
+++ b/sources/kernel/x86_64/pmm.c
@@ -58,7 +58,8 @@ static void pmm_load_memory_map(HandoverMmap const *memory_map)
     {
         size_t base = ALIGN_UP(memory_map->entries[i].base, MEM_PAGE_SIZE);
         size_t size = ALIGN_DOWN(memory_map->entries[i].length, MEM_PAGE_SIZE);
-            
+
+
         /* Avoid duplicate base or top addresses in the bitmap (i.e. unusable entries which have a size of zero) */
         if ((base + size) - 1 != prev_size || base == prev_base)
         {


### PR DESCRIPTION
The pmm was logging the same limit twice for me, which also adds a weird entry to the memory map.

Upstream:
```
type: 3 1000-2afff
type: 0 2b000-9efff
type: 2 a0000-9ffff
type: 2 f0000-fffff
type: 0 100000-1fffff
type: 1 200000-1fffff
type: 1 201000-286fff
```

Patch:
```
type: 3 1000-2afff
type: 0 2b000-9efff
type: 2 a0000-9ffff
type: 2 f0000-fffff
type: 0 100000-1fffff
type: 1 201000-286fff
```