### PR TITLE
Ps2 rework

### DIFF
--- a/sources/libs/brutal/ui/event.h
+++ b/sources/libs/brutal/ui/event.h
@@ -27,6 +27,7 @@ typedef struct
 {
     KbKey key;
     KbMod modifiers;
+    KbMotion motion;
     Rune rune;
 } UiKeyboardEvent;
 

--- a/sources/libs/hw/ps2/controller.c
+++ b/sources/libs/hw/ps2/controller.c
@@ -1,0 +1,116 @@
+#include <hw/ps2/controller.h>
+#include "brutal/debug/assert.h"
+#include "ps2/ps2.h"
+
+uint8_t ps2_controller_status(Ps2Controller* self)
+{
+    return bal_io_in8(self->io, PS2_STATUS_PORT);
+}
+
+static void ps2_wait_read(Ps2Controller* self)
+{
+    int timeout = 100000;
+
+    while(timeout--)
+    {
+        uint8_t status = ps2_controller_status(self);
+        if(!(status == PS2_INPUT_STATUS_FULL))
+        {
+            break;
+        }
+        
+    }
+
+    assert_greater_than(timeout, 0);
+}
+
+static void ps2_wait_write(Ps2Controller* self)
+{
+    int timeout = 100000;
+
+    while(timeout--)
+    {
+        uint8_t status = ps2_controller_status(self);
+        if(status == PS2_OUTPUT_STATUS_FULL)
+        {
+            break;
+        }
+        
+    }
+    assert_greater_than(timeout, 0);
+}
+
+void ps2_controller_write_command (Ps2Controller* self, uint8_t command)
+{
+    ps2_wait_write(self);
+    bal_io_out8(self->io, PS2_COMMAND_PORT, command);
+}
+
+uint8_t ps2_controller_read_data(Ps2Controller* self )
+{
+    ps2_wait_read(self); 
+    return bal_io_in8(self->io, PS2_DATA_PORT);
+}
+
+void ps2_controller_write_data(Ps2Controller* self, uint8_t data )
+{
+    ps2_wait_write(self); 
+    bal_io_out8(self->io, PS2_DATA_PORT, data);
+}
+
+
+void ps2_controller_init(Ps2Controller* self)
+{
+    *self = (Ps2Controller){
+        .io = bal_io_port(0x60, 0x8),
+    };
+
+}
+
+static uint8_t ps2_controller_read_config(Ps2Controller* self)
+{
+    ps2_controller_write_command(self, PS2_CONTROLLER_CONFIG_READ);
+    return ps2_controller_read_data(self);
+}
+static void ps2_controller_write_config(Ps2Controller* self, uint8_t data)
+{
+    ps2_controller_write_command(self, PS2_CONTROLLER_CONFIG_WRITE);
+    ps2_controller_write_data(self, data);
+}
+
+
+void ps2_second_port_init(Ps2Controller* self)
+{
+    ps2_controller_write_command(self, PS2_SECOND_PORT_ENABLE);
+
+    uint8_t status = ps2_controller_read_config(self); 
+    status |= PS2_CFG_SECOND_PORT_INTERRUPT_ENABLE;
+    ps2_controller_write_config(self, status);
+}
+
+void ps2_second_port_write(Ps2Controller* self, uint8_t data)
+{
+    ps2_controller_write_command(self, PS2_WRITE_SECOND_PORT_INPUT);
+    ps2_controller_write_data(self, data);
+}
+
+uint8_t ps2_second_port_read(Ps2Controller* self)
+{
+    ps2_controller_write_command(self, PS2_WRITE_SECOND_PORT_OUTPUT);
+    return ps2_controller_read_data(self);
+}
+
+void ps2_first_port_init(Ps2Controller* self)
+{
+    ps2_controller_write_command(self, PS2_FIRST_PORT_ENABLE);
+
+    uint8_t status = ps2_controller_read_config(self); 
+    status |= PS2_CFG_FIRST_PORT_INTERRUPT_ENABLE;
+    ps2_controller_write_config(self, status);
+}
+
+void ps2_first_port_write(Ps2Controller* self, uint8_t data)
+{
+    ps2_controller_write_command(self, PS2_WRITE_FIRST_PORT_OUTPUT);
+    ps2_controller_write_data(self, data);
+}

--- a/sources/libs/hw/ps2/controller.c
+++ b/sources/libs/hw/ps2/controller.c
@@ -2,114 +2,109 @@
 #include "brutal/debug/assert.h"
 #include "ps2/ps2.h"
 
-uint8_t ps2_controller_status(Ps2Controller* self)
+uint8_t ps2_controller_status(Ps2Controller *self)
 {
     return bal_io_in8(self->io, PS2_STATUS_PORT);
 }
 
-static void ps2_wait_read(Ps2Controller* self)
+static void ps2_wait_read(Ps2Controller *self)
 {
     int timeout = 100000;
 
-    while(timeout--)
+    while (timeout--)
     {
         uint8_t status = ps2_controller_status(self);
-        if(!(status == PS2_INPUT_STATUS_FULL))
+        if ((status & PS2_OUTPUT_STATUS_FULL) == 1)
         {
             break;
         }
-        
     }
 
     assert_greater_than(timeout, 0);
 }
 
-static void ps2_wait_write(Ps2Controller* self)
+static void ps2_wait_write(Ps2Controller *self)
 {
     int timeout = 100000;
 
-    while(timeout--)
+    while (timeout--)
     {
         uint8_t status = ps2_controller_status(self);
-        if(status == PS2_OUTPUT_STATUS_FULL)
+        if ((status & PS2_INPUT_STATUS_FULL) == 0)
         {
             break;
         }
-        
     }
     assert_greater_than(timeout, 0);
 }
 
-void ps2_controller_write_command (Ps2Controller* self, uint8_t command)
+void ps2_controller_write_command(Ps2Controller *self, uint8_t command)
 {
     ps2_wait_write(self);
     bal_io_out8(self->io, PS2_COMMAND_PORT, command);
 }
 
-uint8_t ps2_controller_read_data(Ps2Controller* self )
+uint8_t ps2_controller_read_data(Ps2Controller *self)
 {
-    ps2_wait_read(self); 
+    ps2_wait_read(self);
     return bal_io_in8(self->io, PS2_DATA_PORT);
 }
 
-void ps2_controller_write_data(Ps2Controller* self, uint8_t data )
+void ps2_controller_write_data(Ps2Controller *self, uint8_t data)
 {
-    ps2_wait_write(self); 
+    ps2_wait_write(self);
     bal_io_out8(self->io, PS2_DATA_PORT, data);
 }
 
-
-void ps2_controller_init(Ps2Controller* self)
+void ps2_controller_init(Ps2Controller *self)
 {
     *self = (Ps2Controller){
         .io = bal_io_port(0x60, 0x8),
     };
-
 }
 
-static uint8_t ps2_controller_read_config(Ps2Controller* self)
+static uint8_t ps2_controller_read_config(Ps2Controller *self)
 {
     ps2_controller_write_command(self, PS2_CONTROLLER_CONFIG_READ);
     return ps2_controller_read_data(self);
 }
-static void ps2_controller_write_config(Ps2Controller* self, uint8_t data)
+static void ps2_controller_write_config(Ps2Controller *self, uint8_t data)
 {
     ps2_controller_write_command(self, PS2_CONTROLLER_CONFIG_WRITE);
     ps2_controller_write_data(self, data);
 }
 
-
-void ps2_second_port_init(Ps2Controller* self)
+void ps2_second_port_init(Ps2Controller *self)
 {
     ps2_controller_write_command(self, PS2_SECOND_PORT_ENABLE);
 
-    uint8_t status = ps2_controller_read_config(self); 
+    uint8_t status = ps2_controller_read_config(self);
     status |= PS2_CFG_SECOND_PORT_INTERRUPT_ENABLE;
     ps2_controller_write_config(self, status);
 }
 
-void ps2_second_port_write(Ps2Controller* self, uint8_t data)
+void ps2_second_port_write(Ps2Controller *self, uint8_t data)
 {
     ps2_controller_write_command(self, PS2_WRITE_SECOND_PORT_INPUT);
     ps2_controller_write_data(self, data);
 }
 
-uint8_t ps2_second_port_read(Ps2Controller* self)
+uint8_t ps2_second_port_read(Ps2Controller *self)
 {
     ps2_controller_write_command(self, PS2_WRITE_SECOND_PORT_OUTPUT);
     return ps2_controller_read_data(self);
 }
 
-void ps2_first_port_init(Ps2Controller* self)
+void ps2_first_port_init(Ps2Controller *self)
 {
     ps2_controller_write_command(self, PS2_FIRST_PORT_ENABLE);
 
-    uint8_t status = ps2_controller_read_config(self); 
+    uint8_t status = ps2_controller_read_config(self);
     status |= PS2_CFG_FIRST_PORT_INTERRUPT_ENABLE;
     ps2_controller_write_config(self, status);
 }
 
-void ps2_first_port_write(Ps2Controller* self, uint8_t data)
+void ps2_first_port_write(Ps2Controller *self, uint8_t data)
 {
     ps2_controller_write_command(self, PS2_WRITE_FIRST_PORT_OUTPUT);
     ps2_controller_write_data(self, data);

--- a/sources/libs/hw/ps2/controller.h
+++ b/sources/libs/hw/ps2/controller.h
@@ -1,0 +1,90 @@
+#pragma once 
+#include <bal/hw.h>
+
+/* PS2 8048 driver */
+#define PS2_IO_BASE 0x60
+
+typedef enum 
+{
+    PS2_DATA_PORT = 0,
+    PS2_STATUS_PORT = 4,
+    PS2_COMMAND_PORT = 4,
+} Ps2ControllerRegs;
+
+typedef enum 
+{
+    PS2_OUTPUT_STATUS_FULL = 1 << 0, /* 0: empty 1: full */
+    PS2_INPUT_STATUS_FULL = 1 << 1, /* 0: empty 1: full */
+    PS2_SYS_FLAG = 1 << 2,
+    PS2_DATA_DIRECTION = 1 << 3, /* 0: ps2 device ; 1: ps2 controller */
+    PS2_ERROR_TIMEOUT = 1 << 6,
+    PS2_ERROR_PARITY = 1 << 7
+} Ps2ControllerStatusReg;
+
+typedef enum 
+{
+    PS2_CONTROLLER_CONFIG_READ = 0x20, /* read byte PS2_CONTROLLER_READ + x */
+    PS2_CONTROLLER_CONFIG_WRITE = 0x60,
+    PS2_SECOND_PORT_DISABLE = 0xA7,
+    PS2_SECOND_PORT_ENABLE = 0xA8,
+    PS2_SECOND_PORT_TEST = 0xA9, 
+    PS2_TEST_CONTROLLER = 0xAA,
+    PS2_FIRST_PORT8TEST = 0xAB,
+    PS2_DUMP = 0xAC, 
+    PS2_FIRST_PORT_DISABLE = 0xAD, 
+    PS2_FIRST_PORT_ENABLE = 0xAE,
+    PS2_READ_CONTROLLER_INPUT = 0xC0,
+    /* why do these exist ? */
+    PS2_COPY_LOW_INPUT_TO_HIGH_STATUS = 0xC1,
+    PS2_COPY_HIGH_INPUT_TO_LOW_STATUS = 0xC2,
+    PS2_READ_CONTROLLER_OUTPUT  = 0xD0, 
+    PS2_WRITE_CONTROLLER_OUTPUT = 0xD1,
+    PS2_WRITE_FIRST_PORT_OUTPUT = 0xD2,
+    PS2_WRITE_SECOND_PORT_OUTPUT = 0xD3,
+    PS2_WRITE_SECOND_PORT_INPUT = 0xD4, 
+} Ps2ControllerCommands;
+
+typedef enum 
+{
+    PS2_CFG_FIRST_PORT_INTERRUPT_ENABLE = (1 << 0),
+    PS2_CFG_SECOND_PORT_INTERRUPT_ENABLE = (1 << 1),
+    PS2_CFG_FIRST_PORT_CLOCK_DISABLE = (1 << 4),
+    PS2_CFG_SECOND_PORT_CLOCK_DISABLE = (1 << 5),
+    PS2_CFG_FIRST_TRANSLATION = (1 << 6),
+} Ps2ControllerConfig;
+
+typedef enum 
+{
+    PS2_OUT_RESET  = (1 << 0),
+    PS2_OUT_A20 = (1 << 1),
+    PS2_OUT_SECOND_PORT_CLOCK = (1 << 2), 
+    PS2_OUT_SECOND_PORT_DATA = (1 << 3), 
+    PS2_OUT_FULL_OUTPUT_BUFFER_MOUSE = (1 << 4),
+    PS2_OUT_FULL_OUPUT_BUFFER_KEYBOARD = (1 << 5), 
+    PS2_OUT_FIRST_PORT_CLOCK = (1 << 6), 
+    PS2_OUT_FIRST_PORT_DATA = (1 << 7), 
+} Ps2ControllerOutput;
+
+typedef struct 
+{
+    BalIo io;
+} Ps2Controller;
+
+uint8_t ps2_controller_read_data(Ps2Controller* self );
+void ps2_controller_write_data(Ps2Controller* self, uint8_t data);
+
+void ps2_controller_write_command(Ps2Controller* self, uint8_t command);
+
+void ps2_controller_init(Ps2Controller* self);
+
+uint8_t ps2_controller_status(Ps2Controller* self);
+
+void ps2_second_port_init(Ps2Controller* self);
+
+void ps2_second_port_write(Ps2Controller* self, uint8_t val);
+
+uint8_t ps2_second_port_read(Ps2Controller* self);
+
+void ps2_first_port_init(Ps2Controller* self);
+
+void ps2_first_port_write(Ps2Controller* self, uint8_t val);

--- a/sources/libs/hw/ps2/controller.h
+++ b/sources/libs/hw/ps2/controller.h
@@ -1,50 +1,50 @@
-#pragma once 
+#pragma once
 #include <bal/hw.h>
 
 /* PS2 8048 driver */
 #define PS2_IO_BASE 0x60
 
-typedef enum 
+typedef enum
 {
     PS2_DATA_PORT = 0,
     PS2_STATUS_PORT = 4,
     PS2_COMMAND_PORT = 4,
 } Ps2ControllerRegs;
 
-typedef enum 
+typedef enum
 {
     PS2_OUTPUT_STATUS_FULL = 1 << 0, /* 0: empty 1: full */
-    PS2_INPUT_STATUS_FULL = 1 << 1, /* 0: empty 1: full */
+    PS2_INPUT_STATUS_FULL = 1 << 1,  /* 0: empty 1: full */
     PS2_SYS_FLAG = 1 << 2,
     PS2_DATA_DIRECTION = 1 << 3, /* 0: ps2 device ; 1: ps2 controller */
     PS2_ERROR_TIMEOUT = 1 << 6,
     PS2_ERROR_PARITY = 1 << 7
 } Ps2ControllerStatusReg;
 
-typedef enum 
+typedef enum
 {
     PS2_CONTROLLER_CONFIG_READ = 0x20, /* read byte PS2_CONTROLLER_READ + x */
     PS2_CONTROLLER_CONFIG_WRITE = 0x60,
     PS2_SECOND_PORT_DISABLE = 0xA7,
     PS2_SECOND_PORT_ENABLE = 0xA8,
-    PS2_SECOND_PORT_TEST = 0xA9, 
+    PS2_SECOND_PORT_TEST = 0xA9,
     PS2_TEST_CONTROLLER = 0xAA,
     PS2_FIRST_PORT8TEST = 0xAB,
-    PS2_DUMP = 0xAC, 
-    PS2_FIRST_PORT_DISABLE = 0xAD, 
+    PS2_DUMP = 0xAC,
+    PS2_FIRST_PORT_DISABLE = 0xAD,
     PS2_FIRST_PORT_ENABLE = 0xAE,
     PS2_READ_CONTROLLER_INPUT = 0xC0,
     /* why do these exist ? */
     PS2_COPY_LOW_INPUT_TO_HIGH_STATUS = 0xC1,
     PS2_COPY_HIGH_INPUT_TO_LOW_STATUS = 0xC2,
-    PS2_READ_CONTROLLER_OUTPUT  = 0xD0, 
+    PS2_READ_CONTROLLER_OUTPUT = 0xD0,
     PS2_WRITE_CONTROLLER_OUTPUT = 0xD1,
     PS2_WRITE_FIRST_PORT_OUTPUT = 0xD2,
     PS2_WRITE_SECOND_PORT_OUTPUT = 0xD3,
-    PS2_WRITE_SECOND_PORT_INPUT = 0xD4, 
+    PS2_WRITE_SECOND_PORT_INPUT = 0xD4,
 } Ps2ControllerCommands;
 
-typedef enum 
+typedef enum
 {
     PS2_CFG_FIRST_PORT_INTERRUPT_ENABLE = (1 << 0),
     PS2_CFG_SECOND_PORT_INTERRUPT_ENABLE = (1 << 1),
@@ -53,38 +53,38 @@ typedef enum
     PS2_CFG_FIRST_TRANSLATION = (1 << 6),
 } Ps2ControllerConfig;
 
-typedef enum 
+typedef enum
 {
-    PS2_OUT_RESET  = (1 << 0),
+    PS2_OUT_RESET = (1 << 0),
     PS2_OUT_A20 = (1 << 1),
-    PS2_OUT_SECOND_PORT_CLOCK = (1 << 2), 
-    PS2_OUT_SECOND_PORT_DATA = (1 << 3), 
+    PS2_OUT_SECOND_PORT_CLOCK = (1 << 2),
+    PS2_OUT_SECOND_PORT_DATA = (1 << 3),
     PS2_OUT_FULL_OUTPUT_BUFFER_MOUSE = (1 << 4),
-    PS2_OUT_FULL_OUPUT_BUFFER_KEYBOARD = (1 << 5), 
-    PS2_OUT_FIRST_PORT_CLOCK = (1 << 6), 
-    PS2_OUT_FIRST_PORT_DATA = (1 << 7), 
+    PS2_OUT_FULL_OUPUT_BUFFER_KEYBOARD = (1 << 5),
+    PS2_OUT_FIRST_PORT_CLOCK = (1 << 6),
+    PS2_OUT_FIRST_PORT_DATA = (1 << 7),
 } Ps2ControllerOutput;
 
-typedef struct 
+typedef struct
 {
     BalIo io;
 } Ps2Controller;
 
-uint8_t ps2_controller_read_data(Ps2Controller* self );
-void ps2_controller_write_data(Ps2Controller* self, uint8_t data);
+uint8_t ps2_controller_read_data(Ps2Controller *self);
+void ps2_controller_write_data(Ps2Controller *self, uint8_t data);
 
-void ps2_controller_write_command(Ps2Controller* self, uint8_t command);
+void ps2_controller_write_command(Ps2Controller *self, uint8_t command);
 
-void ps2_controller_init(Ps2Controller* self);
+void ps2_controller_init(Ps2Controller *self);
 
-uint8_t ps2_controller_status(Ps2Controller* self);
+uint8_t ps2_controller_status(Ps2Controller *self);
 
-void ps2_second_port_init(Ps2Controller* self);
+void ps2_second_port_init(Ps2Controller *self);
 
-void ps2_second_port_write(Ps2Controller* self, uint8_t val);
+void ps2_second_port_write(Ps2Controller *self, uint8_t val);
 
-uint8_t ps2_second_port_read(Ps2Controller* self);
+uint8_t ps2_second_port_read(Ps2Controller *self);
 
-void ps2_first_port_init(Ps2Controller* self);
+void ps2_first_port_init(Ps2Controller *self);
 
-void ps2_first_port_write(Ps2Controller* self, uint8_t val);
+void ps2_first_port_write(Ps2Controller *self, uint8_t val);

--- a/sources/libs/hw/ps2/keyboard.c
+++ b/sources/libs/hw/ps2/keyboard.c
@@ -1,0 +1,51 @@
+#include <brutal/input/keyboard.h>
+#include <hw/ps2/keyboard.h>
+#include "brutal/ui/event.h"
+
+void _ps2_keyboard_init(Ps2Keyboard* self, MAYBE_UNUSED Ps2Controller* controller)
+{
+    self->kb_escaped = false;
+}
+
+void ps2_keyboard_handle_code(Ps2Keyboard *ps2, uint8_t packet)
+{
+    if (ps2->kb_escaped)
+    {
+        ps2->kb_escaped = false;
+        KbKey key = (KbKey)((packet & 0x7f) + 0x80);
+        ps2->callback((UiKeyboardEvent){
+            .key = key,
+            .modifiers = packet & 0x80 ? KBMOTION_UP : KBMOTION_DOWN,
+        }, ps2->ctx);
+    }
+    else if (packet == PS2_KEYBOARD_ESCAPED)
+    {
+        ps2->kb_escaped = true;
+    }
+    else
+    {
+        KbKey key = (KbKey)((packet & 0x7f));
+        ps2->callback((UiKeyboardEvent){
+            .key = key,
+            .modifiers = packet & 0x80 ? KBMOTION_UP : KBMOTION_DOWN
+        }, ps2->ctx);
+    }
+}
+
+
+bool ps2_keyboard_interrupt_handle(Ps2Keyboard* self, Ps2Controller* controller)
+{
+    uint8_t status = ps2_controller_status(controller);
+    bool updated = false;
+
+    while (status & PS2_OUTPUT_STATUS_FULL && !(status & 0x20))
+    {
+        uint8_t packet = ps2_controller_read_data(controller);
+
+        ps2_keyboard_handle_code(self, packet);
+        status = ps2_controller_status(controller);
+        updated = true;
+    }
+
+    return updated;
+}

--- a/sources/libs/hw/ps2/keyboard.c
+++ b/sources/libs/hw/ps2/keyboard.c
@@ -2,7 +2,7 @@
 #include <hw/ps2/keyboard.h>
 #include "brutal/ui/event.h"
 
-void _ps2_keyboard_init(Ps2Keyboard* self, MAYBE_UNUSED Ps2Controller* controller)
+void _ps2_keyboard_init(Ps2Keyboard *self, MAYBE_UNUSED Ps2Controller *controller)
 {
     self->kb_escaped = false;
 }
@@ -14,9 +14,10 @@ void ps2_keyboard_handle_code(Ps2Keyboard *ps2, uint8_t packet)
         ps2->kb_escaped = false;
         KbKey key = (KbKey)((packet & 0x7f) + 0x80);
         ps2->callback((UiKeyboardEvent){
-            .key = key,
-            .modifiers = packet & 0x80 ? KBMOTION_UP : KBMOTION_DOWN,
-        }, ps2->ctx);
+                          .key = key,
+                          .modifiers = packet & 0x80 ? KBMOTION_UP : KBMOTION_DOWN,
+                      },
+                      ps2->ctx);
     }
     else if (packet == PS2_KEYBOARD_ESCAPED)
     {
@@ -26,14 +27,14 @@ void ps2_keyboard_handle_code(Ps2Keyboard *ps2, uint8_t packet)
     {
         KbKey key = (KbKey)((packet & 0x7f));
         ps2->callback((UiKeyboardEvent){
-            .key = key,
-            .modifiers = packet & 0x80 ? KBMOTION_UP : KBMOTION_DOWN
-        }, ps2->ctx);
+                          .key = key,
+                          .modifiers = packet & 0x80 ? KBMOTION_UP : KBMOTION_DOWN,
+                      },
+                      ps2->ctx);
     }
 }
 
-
-bool ps2_keyboard_interrupt_handle(Ps2Keyboard* self, Ps2Controller* controller)
+bool ps2_keyboard_interrupt_handle(Ps2Keyboard *self, Ps2Controller *controller)
 {
     uint8_t status = ps2_controller_status(controller);
     bool updated = false;

--- a/sources/libs/hw/ps2/keyboard.h
+++ b/sources/libs/hw/ps2/keyboard.h
@@ -1,21 +1,20 @@
-#pragma once 
+#pragma once
 
 #include <hw/ps2/controller.h>
 #include "brutal/ui/event.h"
 
-typedef void (*Ps2KeyboardCallback)(UiKeyboardEvent ev, void* context);
+typedef void (*Ps2KeyboardCallback)(UiKeyboardEvent ev, void *context);
 
 typedef struct
 {
     bool kb_escaped;
     BrEvent interrupt_handle;
     Ps2KeyboardCallback callback;
-    void * ctx;
+    void *ctx;
 } Ps2Keyboard;
 
 #define PS2_KEYBOARD_ESCAPED 0xE0
 
-void _ps2_keyboard_init(Ps2Keyboard* self, Ps2Controller* controller);
+void _ps2_keyboard_init(Ps2Keyboard *self, Ps2Controller *controller);
 
-bool ps2_keyboard_interrupt_handle(Ps2Keyboard* self, Ps2Controller* controller);
-
+bool ps2_keyboard_interrupt_handle(Ps2Keyboard *self, Ps2Controller *controller);

--- a/sources/libs/hw/ps2/keyboard.h
+++ b/sources/libs/hw/ps2/keyboard.h
@@ -1,0 +1,21 @@
+#pragma once 
+
+#include <hw/ps2/controller.h>
+#include "brutal/ui/event.h"
+
+typedef void (*Ps2KeyboardCallback)(UiKeyboardEvent ev, void* context);
+
+typedef struct
+{
+    bool kb_escaped;
+    BrEvent interrupt_handle;
+    Ps2KeyboardCallback callback;
+    void * ctx;
+} Ps2Keyboard;
+
+#define PS2_KEYBOARD_ESCAPED 0xE0
+
+void _ps2_keyboard_init(Ps2Keyboard* self, Ps2Controller* controller);
+
+bool ps2_keyboard_interrupt_handle(Ps2Keyboard* self, Ps2Controller* controller);
+

--- a/sources/libs/hw/ps2/mouse.c
+++ b/sources/libs/hw/ps2/mouse.c
@@ -95,21 +95,20 @@ bool ps2_mouse_interrupt_handle(Ps2Mouse *self, Ps2Controller *controller)
     return updated;
 }
 
-void ps2_mouse_send(Ps2Controller* controller, uint8_t data)
+void ps2_mouse_send(Ps2Controller *controller, uint8_t data)
 {
     ps2_second_port_write(controller, data);
     ps2_controller_read_data(controller);
 }
 
-void _ps2_mouse_init(Ps2Mouse* self, Ps2Controller* controller)
+void _ps2_mouse_init(Ps2Mouse *self, Ps2Controller *controller)
 {
-    ps2_mouse_send(controller, PS2_MOUSE_CMD_SET_DEFAULT );
+    ps2_mouse_send(controller, PS2_MOUSE_CMD_SET_DEFAULT);
     ps2_mouse_send(controller, PS2_MOUSE_CMD_ENABLE_REPORT);
 
     /* enable scrollwheel */
     ps2_mouse_send(controller, 0xF2);
     ps2_controller_read_data(controller);
-
 
     ps2_mouse_send(controller, PS2_MOUSE_CMD_SET_RATE);
     ps2_mouse_send(controller, 200);
@@ -119,7 +118,6 @@ void _ps2_mouse_init(Ps2Mouse* self, Ps2Controller* controller)
     ps2_mouse_send(controller, 80);
 
     ps2_mouse_send(controller, 0xF2);
-    ps2_controller_read_data(controller);
 
     uint8_t status = ps2_controller_read_data(controller);
 

--- a/sources/libs/hw/ps2/mouse.c
+++ b/sources/libs/hw/ps2/mouse.c
@@ -1,0 +1,127 @@
+#include <hw/ps2/mouse.h>
+#include "ps2/controller.h"
+
+static UiMouseEvent ps2_mouse_status(Ps2Mouse *self)
+{
+    uint8_t const *buf = self->buf;
+
+    int offx = buf[1];
+
+    if (offx && (buf[0] & (1 << 4)))
+    {
+        offx -= 0x100;
+    }
+
+    int offy = buf[2];
+
+    if (offy && (buf[0] & (1 << 5)))
+    {
+        offy -= 0x100;
+    }
+
+    int scroll = 0;
+
+    if (self->wheel)
+    {
+        scroll = (int8_t)buf[3];
+    }
+
+    // decode the new mouse packet
+    UiMouseEvent event = {};
+
+    event.offset.x = offx;
+    event.offset.y = -offy;
+    event.scroll.y = scroll;
+
+    event.buttons |= ((buf[0] >> 0) & 1) ? MSBTN_LEFT : 0;
+    event.buttons |= ((buf[0] >> 1) & 1) ? MSBTN_RIGHT : 0;
+    event.buttons |= ((buf[0] >> 2) & 1) ? MSBTN_MIDDLE : 0;
+
+    return event;
+}
+
+void ps2_mouse_handle_packet(Ps2Mouse *self, uint8_t packet)
+{
+    switch (self->cycle)
+    {
+    case 0:
+        self->buf[0] = packet;
+        if (self->buf[0] & 8)
+        {
+            self->cycle++;
+        }
+        break;
+    case 1:
+        self->buf[1] = packet;
+        self->cycle++;
+        break;
+    case 2:
+        self->buf[2] = packet;
+
+        if (self->wheel)
+        {
+            self->cycle++;
+        }
+        else
+        {
+            self->callback(ps2_mouse_status(self), self->ctx);
+            self->cycle = 0;
+        }
+
+        break;
+    case 3:
+        self->buf[3] = packet;
+        self->callback(ps2_mouse_status(self), self->ctx);
+        self->cycle = 0;
+        break;
+    }
+}
+
+bool ps2_mouse_interrupt_handle(Ps2Mouse *self, Ps2Controller *controller)
+{
+    uint8_t status = ps2_controller_status(controller);
+    bool updated = false;
+
+    while (status & PS2_OUTPUT_STATUS_FULL && status & 0x20)
+    {
+        uint8_t packet = ps2_controller_read_data(controller);
+
+        ps2_mouse_handle_packet(self, packet);
+
+        status = ps2_controller_status(controller);
+        updated = true;
+    }
+
+    return updated;
+}
+
+void ps2_mouse_send(Ps2Controller* controller, uint8_t data)
+{
+    ps2_second_port_write(controller, data);
+    ps2_controller_read_data(controller);
+}
+
+void _ps2_mouse_init(Ps2Mouse* self, Ps2Controller* controller)
+{
+    ps2_mouse_send(controller, PS2_MOUSE_CMD_SET_DEFAULT );
+    ps2_mouse_send(controller, PS2_MOUSE_CMD_ENABLE_REPORT);
+
+    /* enable scrollwheel */
+    ps2_mouse_send(controller, 0xF2);
+    ps2_controller_read_data(controller);
+
+
+    ps2_mouse_send(controller, PS2_MOUSE_CMD_SET_RATE);
+    ps2_mouse_send(controller, 200);
+    ps2_mouse_send(controller, PS2_MOUSE_CMD_SET_RATE);
+    ps2_mouse_send(controller, 100);
+    ps2_mouse_send(controller, PS2_MOUSE_CMD_SET_RATE);
+    ps2_mouse_send(controller, 80);
+
+    ps2_mouse_send(controller, 0xF2);
+    ps2_controller_read_data(controller);
+
+    uint8_t status = ps2_controller_read_data(controller);
+
+    self->wheel = status == 3;
+}

--- a/sources/libs/hw/ps2/mouse.h
+++ b/sources/libs/hw/ps2/mouse.h
@@ -1,0 +1,39 @@
+#pragma once 
+
+#include <brutal/base.h>
+#include <hw/ps2/controller.h>
+#include "brutal/ui/event.h"
+
+typedef void (*Ps2MouseCallback)(UiMouseEvent ev, void* ctx);
+
+typedef struct 
+{
+    uint8_t cycle;
+    uint8_t buf[4];
+    bool wheel;
+    BrEvent interrupt_handle;
+    Ps2MouseCallback callback;
+    void* ctx;
+} Ps2Mouse;
+
+typedef enum {
+    PS2_MOUSE_CMD_RESET = 0xff,
+    PS2_MOUSE_CMD_RESEND = 0xfe,
+    PS2_MOUSE_CMD_SET_DEFAULT = 0xf6,
+    PS2_MOUSE_CMD_DISABLE_REPORT  = 0xf5,
+    PS2_MOUSE_CMD_ENABLE_REPORT  = 0xf4,
+    PS2_MOUSE_CMD_SET_RATE  = 0xf3,
+    PS2_MOUSE_CMD_DEV_ID = 0xf2,
+    PS2_MOUSE_CMD_REMOTE_MODE = 0xf0,
+    PS2_MOUSE_CMD_WRAP_MODE = 0xee,
+    PS2_MOUSE_CMD_WRAP_RESET  = 0xec,
+    PS2_MOUSE_CMD_READ_DATA = 0xeb,
+    PS2_MOUSE_CMD_SET_STREAM_MODE = 0xea,
+    PS2_MOUSE_CMD_STATUS_REQUEST  = 0xe9,
+    PS2_MOUSE_CMD_SET_RESOLUTION = 0xe8,
+    PS2_MOUSE_CMD_SET_SCALING = 0xe6,
+} Ps2MouseCommands;
+
+void _ps2_mouse_init(Ps2Mouse* self, Ps2Controller* controller);
+
+bool ps2_mouse_interrupt_handle(Ps2Mouse* self, Ps2Controller* controller);

--- a/sources/libs/hw/ps2/mouse.h
+++ b/sources/libs/hw/ps2/mouse.h
@@ -1,39 +1,40 @@
-#pragma once 
+#pragma once
 
 #include <brutal/base.h>
 #include <hw/ps2/controller.h>
 #include "brutal/ui/event.h"
 
-typedef void (*Ps2MouseCallback)(UiMouseEvent ev, void* ctx);
+typedef void (*Ps2MouseCallback)(UiMouseEvent ev, void *ctx);
 
-typedef struct 
+typedef struct
 {
     uint8_t cycle;
     uint8_t buf[4];
     bool wheel;
     BrEvent interrupt_handle;
     Ps2MouseCallback callback;
-    void* ctx;
+    void *ctx;
 } Ps2Mouse;
 
-typedef enum {
+typedef enum
+{
     PS2_MOUSE_CMD_RESET = 0xff,
     PS2_MOUSE_CMD_RESEND = 0xfe,
     PS2_MOUSE_CMD_SET_DEFAULT = 0xf6,
-    PS2_MOUSE_CMD_DISABLE_REPORT  = 0xf5,
-    PS2_MOUSE_CMD_ENABLE_REPORT  = 0xf4,
-    PS2_MOUSE_CMD_SET_RATE  = 0xf3,
+    PS2_MOUSE_CMD_DISABLE_REPORT = 0xf5,
+    PS2_MOUSE_CMD_ENABLE_REPORT = 0xf4,
+    PS2_MOUSE_CMD_SET_RATE = 0xf3,
     PS2_MOUSE_CMD_DEV_ID = 0xf2,
     PS2_MOUSE_CMD_REMOTE_MODE = 0xf0,
     PS2_MOUSE_CMD_WRAP_MODE = 0xee,
-    PS2_MOUSE_CMD_WRAP_RESET  = 0xec,
+    PS2_MOUSE_CMD_WRAP_RESET = 0xec,
     PS2_MOUSE_CMD_READ_DATA = 0xeb,
     PS2_MOUSE_CMD_SET_STREAM_MODE = 0xea,
-    PS2_MOUSE_CMD_STATUS_REQUEST  = 0xe9,
+    PS2_MOUSE_CMD_STATUS_REQUEST = 0xe9,
     PS2_MOUSE_CMD_SET_RESOLUTION = 0xe8,
     PS2_MOUSE_CMD_SET_SCALING = 0xe6,
 } Ps2MouseCommands;
 
-void _ps2_mouse_init(Ps2Mouse* self, Ps2Controller* controller);
+void _ps2_mouse_init(Ps2Mouse *self, Ps2Controller *controller);
 
-bool ps2_mouse_interrupt_handle(Ps2Mouse* self, Ps2Controller* controller);
+bool ps2_mouse_interrupt_handle(Ps2Mouse *self, Ps2Controller *controller);

--- a/sources/libs/hw/ps2/ps2.c
+++ b/sources/libs/hw/ps2/ps2.c
@@ -1,0 +1,116 @@
+#include <hw/ps2/ps2.h>
+#include "brutal/debug/assert.h"
+#include "ps2/ps2.h"
+
+static uint8_t ps2_status(Ps2Controller* self)
+{
+    return bal_io_in8(self->io, PS2_REG_STATUS);
+}
+
+static void ps2_wait_read(Ps2Controller* self)
+{
+    int timeout = 100000;
+
+    while(timeout--)
+    {
+        uint8_t status = ps2_status(self);
+        if(!(status == PS2_INPUT_STATUS_FULL))
+        {
+            break;
+        }
+        
+    }
+
+    assert_greater_than(timeout, 0);
+}
+
+static void ps2_wait_write(Ps2Controller* self)
+{
+    int timeout = 100000;
+
+    while(timeout--)
+    {
+        uint8_t status = ps2_status(self);
+        if(status == PS2_OUPUT_STATUS_FULL)
+        {
+            break;
+        }
+        
+    }
+    assert_greater_than(timeout, 0);
+}
+
+static void ps2_write_command (Ps2Controller* self, uint8_t command)
+{
+    ps2_wait_write(self);
+    bal_io_out8(self->io, PS2_COMMAND_PORT, command);
+}
+
+static uint8_t ps2_read_data(Ps2Controller* self )
+{
+    ps2_wait_read(self); 
+    return bal_io_in8(self->io, PS2_DATA_PORT);
+}
+
+static void ps2_write_data(Ps2Controller* self, uint8_t data )
+{
+    ps2_wait_write(self); 
+     bal_io_out8(self->io, PS2_DATA_PORT, data);
+}
+
+
+void ps2_controller_init(Ps2Controller* self)
+{
+    *self = (Ps2Controller){
+        .io = bal_io_port(0x60, 0x8),
+    };
+
+}
+
+static uint8_t ps2_controller_read_config(Ps2Controller* self)
+{
+    ps2_write_command(self, PS2_CONTROLLER_CONFIG_READ);
+    return ps2_read_data(self);
+}
+static void ps2_controller_write_config(Ps2Controller* self, uint8_t data)
+{
+    ps2_write_command(self, PS2_CONTROLLER_CONFIG_WRITE);
+    ps2_write_data(self, data);
+}
+
+
+void ps2_second_port_init(Ps2Controller* self)
+{
+    ps2_write_command(self, PS2_SECOND_PORT_ENABLE);
+
+    uint8_t status = ps2_controller_read_config(self); 
+    status |= PS2_CFG_SECOND_PORT_INTERRUPT_ENABLE;
+    ps2_controller_write_config(self, status);
+}
+
+void ps2_second_port_write(Ps2Controller* self, uint8_t data)
+{
+    ps2_write_command(self, PS2_WRITE_SECOND_PORT_INPUT);
+    ps2_write_data(self, data);
+}
+
+uint8_t ps2_second_port_read(Ps2Controller* self)
+{
+    ps2_write_command(self, PS2_WRITE_SECOND_PORT_OUTPUT);
+    return ps2_read_data(self);
+}
+
+void ps2_first_port_init(Ps2Controller* self)
+{
+    ps2_write_command(self, PS2_FIRST_PORT_ENABLE);
+
+    uint8_t status = ps2_controller_read_config(self); 
+    status |= PS2_CFG_FIRST_PORT_INTERRUPT_ENABLE;
+    ps2_controller_write_config(self, status);
+}
+
+void ps2_first_port_write(Ps2Controller* self, uint8_t data)
+{
+    ps2_write_command(self, PS2_WRITE_FIRST_PORT_OUTPUT);
+    ps2_write_data(self, data);
+}

--- a/sources/libs/hw/ps2/ps2.c
+++ b/sources/libs/hw/ps2/ps2.c
@@ -1,116 +1,63 @@
 #include <hw/ps2/ps2.h>
-#include "brutal/debug/assert.h"
-#include "ps2/ps2.h"
+#include "bal/abi/syscalls.h"
+#include "bal/abi/types.h"
+#include "ps2/controller.h"
+#include "ps2/mouse.h"
 
-static uint8_t ps2_status(Ps2Controller* self)
+
+void init_ps2_mouse(Ps2* ps2, Ps2MouseCallback callback, void* ctx)
 {
-    return bal_io_in8(self->io, PS2_REG_STATUS);
+    ps2_second_port_init(&ps2->controller);
+    ps2->mouse.interrupt_handle = (BrEvent){
+        .type = BR_EVENT_IRQ,
+        .irq = 12,
+    };
+    br_bind(&(BrBindArgs){.event = ps2->mouse.interrupt_handle});
+
+    ps2->mouse.callback = callback;
+    ps2->mouse.ctx = ctx;
+    _ps2_mouse_init(&ps2->mouse, &ps2->controller);
+
 }
 
-static void ps2_wait_read(Ps2Controller* self)
+void init_ps2_keyboard(Ps2* ps2, Ps2KeyboardCallback callback, void* ctx)
 {
-    int timeout = 100000;
 
-    while(timeout--)
-    {
-        uint8_t status = ps2_status(self);
-        if(!(status == PS2_INPUT_STATUS_FULL))
-        {
-            break;
-        }
-        
-    }
-
-    assert_greater_than(timeout, 0);
-}
-
-static void ps2_wait_write(Ps2Controller* self)
-{
-    int timeout = 100000;
-
-    while(timeout--)
-    {
-        uint8_t status = ps2_status(self);
-        if(status == PS2_OUPUT_STATUS_FULL)
-        {
-            break;
-        }
-        
-    }
-    assert_greater_than(timeout, 0);
-}
-
-static void ps2_write_command (Ps2Controller* self, uint8_t command)
-{
-    ps2_wait_write(self);
-    bal_io_out8(self->io, PS2_COMMAND_PORT, command);
-}
-
-static uint8_t ps2_read_data(Ps2Controller* self )
-{
-    ps2_wait_read(self); 
-    return bal_io_in8(self->io, PS2_DATA_PORT);
-}
-
-static void ps2_write_data(Ps2Controller* self, uint8_t data )
-{
-    ps2_wait_write(self); 
-     bal_io_out8(self->io, PS2_DATA_PORT, data);
-}
-
-
-void ps2_controller_init(Ps2Controller* self)
-{
-    *self = (Ps2Controller){
-        .io = bal_io_port(0x60, 0x8),
+    ps2_first_port_init(&ps2->controller);
+    ps2->keyboard.interrupt_handle = (BrEvent){
+        .type = BR_EVENT_IRQ,
+        .irq = 1,
     };
 
+    br_bind(&(BrBindArgs){
+        .event = ps2->keyboard.interrupt_handle});
+
+    ps2->keyboard.callback = callback;
+    ps2->keyboard.ctx = ctx;
+    _ps2_keyboard_init(&ps2->keyboard, &ps2->controller);
 }
 
-static uint8_t ps2_controller_read_config(Ps2Controller* self)
+Ps2Devices ps2_interrupt_handle(Ps2 *ps2, BrEvent ev)
 {
-    ps2_write_command(self, PS2_CONTROLLER_CONFIG_READ);
-    return ps2_read_data(self);
-}
-static void ps2_controller_write_config(Ps2Controller* self, uint8_t data)
-{
-    ps2_write_command(self, PS2_CONTROLLER_CONFIG_WRITE);
-    ps2_write_data(self, data);
-}
+    if (ev.irq != 1 && ev.irq != 12)
+    {
+        return PS2_NONE;
+    }
 
+    Ps2Devices devices = PS2_NONE;
 
-void ps2_second_port_init(Ps2Controller* self)
-{
-    ps2_write_command(self, PS2_SECOND_PORT_ENABLE);
+    if (ev.irq == 1 && ps2_keyboard_interrupt_handle(&ps2->keyboard, &ps2->controller))
+    {
+        devices |= PS2_KEYBOARD;
+    }
+    else if (ev.irq == 12 && ps2_mouse_interrupt_handle(&ps2->mouse, &ps2->controller))
+    {
+        devices |= PS2_MOUSE;
+    }
 
-    uint8_t status = ps2_controller_read_config(self); 
-    status |= PS2_CFG_SECOND_PORT_INTERRUPT_ENABLE;
-    ps2_controller_write_config(self, status);
-}
-
-void ps2_second_port_write(Ps2Controller* self, uint8_t data)
-{
-    ps2_write_command(self, PS2_WRITE_SECOND_PORT_INPUT);
-    ps2_write_data(self, data);
-}
-
-uint8_t ps2_second_port_read(Ps2Controller* self)
-{
-    ps2_write_command(self, PS2_WRITE_SECOND_PORT_OUTPUT);
-    return ps2_read_data(self);
-}
-
-void ps2_first_port_init(Ps2Controller* self)
-{
-    ps2_write_command(self, PS2_FIRST_PORT_ENABLE);
-
-    uint8_t status = ps2_controller_read_config(self); 
-    status |= PS2_CFG_FIRST_PORT_INTERRUPT_ENABLE;
-    ps2_controller_write_config(self, status);
-}
-
-void ps2_first_port_write(Ps2Controller* self, uint8_t data)
-{
-    ps2_write_command(self, PS2_WRITE_FIRST_PORT_OUTPUT);
-    ps2_write_data(self, data);
+    if(devices != 0)
+    {
+        br_ack(&(BrAckArgs){.event = ev});
+    }
+    return devices;
 }

--- a/sources/libs/hw/ps2/ps2.c
+++ b/sources/libs/hw/ps2/ps2.c
@@ -1,26 +1,41 @@
+#include <bal/abi.h>
 #include <hw/ps2/ps2.h>
-#include "bal/abi/syscalls.h"
-#include "bal/abi/types.h"
 #include "ps2/controller.h"
 #include "ps2/mouse.h"
 
+void ps2_interrupt_handle(Ps2 *ps2, BrEvent ev)
+{
+    if (ev.type != BR_EVENT_IRQ || (ev.irq != 1 && ev.irq != 12))
+    {
+        return;
+    }
+    if (ev.irq == 1 && ps2_keyboard_interrupt_handle(&ps2->keyboard, &ps2->controller))
+    {
+        br_ack(&(BrAckArgs){.event = ev});
+        return;
+    }
+    else if (ev.irq == 12 && ps2_mouse_interrupt_handle(&ps2->mouse, &ps2->controller))
+    {
+        br_ack(&(BrAckArgs){.event = ev});
+        return;
+    }
+    br_ack(&(BrAckArgs){.event = ev});
+}
 
-void init_ps2_mouse(Ps2* ps2, Ps2MouseCallback callback, void* ctx)
+void init_ps2_mouse(Ps2 *ps2, Ps2MouseCallback callback, void *ctx)
 {
     ps2_second_port_init(&ps2->controller);
     ps2->mouse.interrupt_handle = (BrEvent){
         .type = BR_EVENT_IRQ,
         .irq = 12,
     };
-    br_bind(&(BrBindArgs){.event = ps2->mouse.interrupt_handle});
-
+    ipc_component_bind(ps2->ipc, ps2->mouse.interrupt_handle, (IpcEventHandler *)ps2_interrupt_handle, ps2);
     ps2->mouse.callback = callback;
     ps2->mouse.ctx = ctx;
     _ps2_mouse_init(&ps2->mouse, &ps2->controller);
-
 }
 
-void init_ps2_keyboard(Ps2* ps2, Ps2KeyboardCallback callback, void* ctx)
+void init_ps2_keyboard(Ps2 *ps2, Ps2KeyboardCallback callback, void *ctx)
 {
 
     ps2_first_port_init(&ps2->controller);
@@ -29,35 +44,16 @@ void init_ps2_keyboard(Ps2* ps2, Ps2KeyboardCallback callback, void* ctx)
         .irq = 1,
     };
 
-    br_bind(&(BrBindArgs){
-        .event = ps2->keyboard.interrupt_handle});
+    ipc_component_bind(ps2->ipc, ps2->keyboard.interrupt_handle, (IpcEventHandler *)ps2_interrupt_handle, ps2);
 
     ps2->keyboard.callback = callback;
     ps2->keyboard.ctx = ctx;
     _ps2_keyboard_init(&ps2->keyboard, &ps2->controller);
 }
-
-Ps2Devices ps2_interrupt_handle(Ps2 *ps2, BrEvent ev)
+void init_ps2(Ps2 *ps2, IpcComponent *ipc)
 {
-    if (ev.irq != 1 && ev.irq != 12)
-    {
-        return PS2_NONE;
-    }
-
-    Ps2Devices devices = PS2_NONE;
-
-    if (ev.irq == 1 && ps2_keyboard_interrupt_handle(&ps2->keyboard, &ps2->controller))
-    {
-        devices |= PS2_KEYBOARD;
-    }
-    else if (ev.irq == 12 && ps2_mouse_interrupt_handle(&ps2->mouse, &ps2->controller))
-    {
-        devices |= PS2_MOUSE;
-    }
-
-    if(devices != 0)
-    {
-        br_ack(&(BrAckArgs){.event = ev});
-    }
-    return devices;
+    ps2->ipc = ipc;
+    log$("owo");
+    ps2_controller_init(&ps2->controller);
+    log$("awa");
 }

--- a/sources/libs/hw/ps2/ps2.h
+++ b/sources/libs/hw/ps2/ps2.h
@@ -1,15 +1,16 @@
-#pragma once 
+#pragma once
 
 #include <hw/ps2/controller.h>
-#include <hw/ps2/mouse.h>
 #include <hw/ps2/keyboard.h>
+#include <hw/ps2/mouse.h>
+#include <ipc/component.h>
 
-
-typedef struct 
+typedef struct
 {
-    Ps2Controller controller; 
+    Ps2Controller controller;
     Ps2Mouse mouse;
     Ps2Keyboard keyboard;
+    IpcComponent *ipc;
 } Ps2;
 
 typedef enum
@@ -19,8 +20,8 @@ typedef enum
     PS2_KEYBOARD = 1 << 2,
 } Ps2Devices;
 
-void init_ps2_mouse(Ps2* ps2, Ps2MouseCallback callback, void* ctx);
+void init_ps2_mouse(Ps2 *ps2, Ps2MouseCallback callback, void *ctx);
 
-void init_ps2_keyboard(Ps2* ps2, Ps2KeyboardCallback callback, void* ctx);
+void init_ps2_keyboard(Ps2 *ps2, Ps2KeyboardCallback callback, void *ctx);
 
-Ps2Devices ps2_interrupt_handle(Ps2* ps2, BrEvent ev);
+void init_ps2(Ps2 *ps2, IpcComponent *ipc);

--- a/sources/libs/hw/ps2/ps2.h
+++ b/sources/libs/hw/ps2/ps2.h
@@ -1,0 +1,85 @@
+#pragma once 
+#include <bal/hw.h>
+
+/* PS2 8048 driver */
+#define PS2_IO_BASE 0x60
+
+typedef enum 
+{
+    PS2_DATA_PORT = 0,
+    PS2_STATUS_PORT = 4,
+    PS2_COMMAND_PORT = 4,
+} Ps2ControllerRegs;
+
+typedef enum 
+{
+    PS2_OUPUT_STATUS_FULL = 1 << 0, /* 0: empty 1: full */
+    PS2_INPUT_STATUS_FULL = 1 << 1, /* 0: empty 1: full */
+    PS2_SYS_FLAG = 1 << 2,
+    PS2_DATA_DIRECTION = 1 << 3, /* 0: ps2 device ; 1: ps2 controller */
+    PS2_ERROR_TIMEOUT = 1 << 6,
+    PS2_ERROR_PARITY = 1 << 7
+} Ps2ControllerStatusReg;
+
+typedef enum 
+{
+    PS2_CONTROLLER_CONFIG_READ = 0x20, /* read byte PS2_CONTROLLER_READ + x */
+    PS2_CONTROLLER_CONFIG_WRITE = 0x60,
+    PS2_SECOND_PORT_DISABLE = 0xA7,
+    PS2_SECOND_PORT_ENABLE = 0xA8,
+    PS2_SECOND_PORT_TEST = 0xA9, 
+    PS2_TEST_CONTROLLER = 0xAA,
+    PS2_FIRST_PORT8TEST = 0xAB,
+    PS2_DUMP = 0xAC, 
+    PS2_FIRST_PORT_DISABLE = 0xAD, 
+    PS2_FIRST_PORT_ENABLE = 0xAE,
+    PS2_READ_CONTROLLER_INPUT = 0xC0,
+    /* why do these exist ? */
+    PS2_COPY_LOW_INPUT_TO_HIGH_STATUS = 0xC1,
+    PS2_COPY_HIGH_INPUT_TO_LOW_STATUS = 0xC2,
+    PS2_READ_CONTROLLER_OUTPUT  = 0xD0, 
+    PS2_WRITE_CONTROLLER_OUTPUT = 0xD1,
+    PS2_WRITE_FIRST_PORT_OUTPUT = 0xD2,
+    PS2_WRITE_SECOND_PORT_OUTPUT = 0xD3,
+    PS2_WRITE_SECOND_PORT_INPUT = 0xD4, 
+} Ps2ControllerCommands;
+
+typedef enum 
+{
+    PS2_CFG_FIRST_PORT_INTERRUPT_ENABLE = (1 << 0),
+    PS2_CFG_SECOND_PORT_INTERRUPT_ENABLE = (1 << 1),
+    PS2_CFG_FIRST_PORT_CLOCK_DISABLE = (1 << 4),
+    PS2_CFG_SECOND_PORT_CLOCK_DISABLE = (1 << 5),
+    PS2_CFG_FIRST_TRANSLATION = (1 << 6),
+} Ps2ControllerConfig;
+
+typedef enum 
+{
+    PS2_OUT_RESET  = (1 << 0),
+    PS2_OUT_A20 = (1 << 1),
+    PS2_OUT_SECOND_PORT_CLOCK = (1 << 2), 
+    PS2_OUT_SECOND_PORT_DATA = (1 << 3), 
+    PS2_OUT_FULL_OUTPUT_BUFFER_MOUSE = (1 << 4),
+    PS2_OUT_FULL_OUPUT_BUFFER_KEYBOARD = (1 << 5), 
+    PS2_OUT_FIRST_PORT_CLOCK = (1 << 6), 
+    PS2_OUT_FIRST_PORT_DATA = (1 << 7), 
+} Ps2ControllerOutput;
+
+typedef struct 
+{
+    BalIo io;
+} Ps2Controller;
+
+
+void ps2_controller_init(Ps2Controller* self);
+
+void ps2_second_port_init(Ps2Controller* self);
+
+void ps2_second_port_write(Ps2Controller* self, uint8_t val);
+
+uint8_t ps2_second_port_read(Ps2Controller* self);
+
+void ps2_first_port_init(Ps2Controller* self);
+
+void ps2_first_port_write(Ps2Controller* self, uint8_t val);
+

--- a/sources/libs/hw/ps2/ps2.h
+++ b/sources/libs/hw/ps2/ps2.h
@@ -1,85 +1,26 @@
 #pragma once 
-#include <bal/hw.h>
 
-/* PS2 8048 driver */
-#define PS2_IO_BASE 0x60
+#include <hw/ps2/controller.h>
+#include <hw/ps2/mouse.h>
+#include <hw/ps2/keyboard.h>
 
-typedef enum 
-{
-    PS2_DATA_PORT = 0,
-    PS2_STATUS_PORT = 4,
-    PS2_COMMAND_PORT = 4,
-} Ps2ControllerRegs;
-
-typedef enum 
-{
-    PS2_OUPUT_STATUS_FULL = 1 << 0, /* 0: empty 1: full */
-    PS2_INPUT_STATUS_FULL = 1 << 1, /* 0: empty 1: full */
-    PS2_SYS_FLAG = 1 << 2,
-    PS2_DATA_DIRECTION = 1 << 3, /* 0: ps2 device ; 1: ps2 controller */
-    PS2_ERROR_TIMEOUT = 1 << 6,
-    PS2_ERROR_PARITY = 1 << 7
-} Ps2ControllerStatusReg;
-
-typedef enum 
-{
-    PS2_CONTROLLER_CONFIG_READ = 0x20, /* read byte PS2_CONTROLLER_READ + x */
-    PS2_CONTROLLER_CONFIG_WRITE = 0x60,
-    PS2_SECOND_PORT_DISABLE = 0xA7,
-    PS2_SECOND_PORT_ENABLE = 0xA8,
-    PS2_SECOND_PORT_TEST = 0xA9, 
-    PS2_TEST_CONTROLLER = 0xAA,
-    PS2_FIRST_PORT8TEST = 0xAB,
-    PS2_DUMP = 0xAC, 
-    PS2_FIRST_PORT_DISABLE = 0xAD, 
-    PS2_FIRST_PORT_ENABLE = 0xAE,
-    PS2_READ_CONTROLLER_INPUT = 0xC0,
-    /* why do these exist ? */
-    PS2_COPY_LOW_INPUT_TO_HIGH_STATUS = 0xC1,
-    PS2_COPY_HIGH_INPUT_TO_LOW_STATUS = 0xC2,
-    PS2_READ_CONTROLLER_OUTPUT  = 0xD0, 
-    PS2_WRITE_CONTROLLER_OUTPUT = 0xD1,
-    PS2_WRITE_FIRST_PORT_OUTPUT = 0xD2,
-    PS2_WRITE_SECOND_PORT_OUTPUT = 0xD3,
-    PS2_WRITE_SECOND_PORT_INPUT = 0xD4, 
-} Ps2ControllerCommands;
-
-typedef enum 
-{
-    PS2_CFG_FIRST_PORT_INTERRUPT_ENABLE = (1 << 0),
-    PS2_CFG_SECOND_PORT_INTERRUPT_ENABLE = (1 << 1),
-    PS2_CFG_FIRST_PORT_CLOCK_DISABLE = (1 << 4),
-    PS2_CFG_SECOND_PORT_CLOCK_DISABLE = (1 << 5),
-    PS2_CFG_FIRST_TRANSLATION = (1 << 6),
-} Ps2ControllerConfig;
-
-typedef enum 
-{
-    PS2_OUT_RESET  = (1 << 0),
-    PS2_OUT_A20 = (1 << 1),
-    PS2_OUT_SECOND_PORT_CLOCK = (1 << 2), 
-    PS2_OUT_SECOND_PORT_DATA = (1 << 3), 
-    PS2_OUT_FULL_OUTPUT_BUFFER_MOUSE = (1 << 4),
-    PS2_OUT_FULL_OUPUT_BUFFER_KEYBOARD = (1 << 5), 
-    PS2_OUT_FIRST_PORT_CLOCK = (1 << 6), 
-    PS2_OUT_FIRST_PORT_DATA = (1 << 7), 
-} Ps2ControllerOutput;
 
 typedef struct 
 {
-    BalIo io;
-} Ps2Controller;
+    Ps2Controller controller; 
+    Ps2Mouse mouse;
+    Ps2Keyboard keyboard;
+} Ps2;
 
+typedef enum
+{
+    PS2_NONE = 0,
+    PS2_MOUSE = 1 << 1,
+    PS2_KEYBOARD = 1 << 2,
+} Ps2Devices;
 
-void ps2_controller_init(Ps2Controller* self);
+void init_ps2_mouse(Ps2* ps2, Ps2MouseCallback callback, void* ctx);
 
-void ps2_second_port_init(Ps2Controller* self);
+void init_ps2_keyboard(Ps2* ps2, Ps2KeyboardCallback callback, void* ctx);
 
-void ps2_second_port_write(Ps2Controller* self, uint8_t val);
-
-uint8_t ps2_second_port_read(Ps2Controller* self);
-
-void ps2_first_port_init(Ps2Controller* self);
-
-void ps2_first_port_write(Ps2Controller* self, uint8_t val);
-
+Ps2Devices ps2_interrupt_handle(Ps2* ps2, BrEvent ev);

--- a/sources/pkgs/.user.mk
+++ b/sources/pkgs/.user.mk
@@ -19,6 +19,7 @@ LIBS_SRC = \
 	$(wildcard sources/libs/hw/fdt/*.c) \
 	$(wildcard sources/libs/hw/pci/*.c) \
 	$(wildcard sources/libs/hw/ahci/*.c) \
+	$(wildcard sources/libs/hw/ps2/*.c) \
 	$(wildcard sources/libs/json/*.c) \
 	$(wildcard sources/libs/stdc/*/*.c) \
 	$(wildcard sources/libs/ubsan/*.c)

--- a/sources/pkgs/ps2/main.c
+++ b/sources/pkgs/ps2/main.c
@@ -5,275 +5,72 @@
 #include <brutal/ui.h>
 #include <ipc/ipc.h>
 #include <protos/event.h>
-#include "ps2/ps2.h"
+#include "bal/abi/types.h"
+#include "brutal/ui/event.h"
+#include <hw/ps2/ps2.h>
 
 typedef struct
 {
     BalIo io;
-    bool kb_escaped;
-
-    uint8_t mouse_cycle;
-    uint8_t mouse_buf[4];
-    bool mouse_has_wheel;
 
     IpcCap input_sink;
-} Ps2;
+} Ps2Ctx;
 
-void ps2_keyboard_handle_key(Ps2 *ps2, KbKey key, KbMotion motion)
+void ps2_keyboard_callback(UiKeyboardEvent ev, void* ps2)
 {
-    log$("ps2kb: key={} motion={}", kbkey_to_str(key), motion ? "down" : "up");
-    UiEvent event = {
+    bool handled = false;
+
+     UiEvent event = {
         .type = UI_EVENT_KEYBOARD_TYPED,
+        .keyboard = ev,
     };
 
-    bool handled = false;
-    event_sink_dispatch_rpc(ipc_component_self(), ps2->input_sink, &event, &handled, alloc_global());
+
+    event_sink_dispatch_rpc(ipc_component_self(), ((Ps2Ctx*)ps2)->input_sink, &event, &handled, alloc_global());
 }
 
-void ps2_mouse_handle_event(Ps2 *ps2, MAYBE_UNUSED UiMouseEvent e)
+void ps2_mouse_callback(UiMouseEvent ev, void* ps2)
 {
-    UiEvent event = {
+    bool handled = false;
+
+     UiEvent event = {
         .type = UI_EVENT_MOUSE_MOVE,
-        .mouse = e,
+        .mouse = ev,
     };
 
-    bool handled = false;
-    event_sink_dispatch_rpc(ipc_component_self(), ps2->input_sink, &event, &handled, alloc_global());
+
+    event_sink_dispatch_rpc(ipc_component_self(), ((Ps2Ctx*)ps2)->input_sink, &event, &handled, alloc_global());
 }
 
-void ps2_keyboard_handle_code(Ps2 *ps2, uint8_t packet)
-{
-    if (ps2->kb_escaped)
-    {
-        ps2->kb_escaped = false;
-        KbKey key = (KbKey)((packet & 0x7f) + 0x80);
-        ps2_keyboard_handle_key(ps2, key, packet & 0x80 ? KBMOTION_UP : KBMOTION_DOWN);
-    }
-    else if (packet == PS2_KEYBOARD_ESCAPE)
-    {
-        ps2->kb_escaped = true;
-    }
-    else
-    {
-        KbKey key = (KbKey)(packet & 0x7f);
-        ps2_keyboard_handle_key(ps2, key, packet & 0x80 ? KBMOTION_UP : KBMOTION_DOWN);
-    }
-}
-
-void ps2_mouse_handle_finished(Ps2 *ps2)
-{
-    uint8_t const *buf = ps2->mouse_buf;
-
-    int offx = buf[1];
-
-    if (offx && (buf[0] & (1 << 4)))
-    {
-        offx -= 0x100;
-    }
-
-    int offy = buf[2];
-
-    if (offy && (buf[0] & (1 << 5)))
-    {
-        offy -= 0x100;
-    }
-
-    int scroll = 0;
-
-    if (ps2->mouse_has_wheel)
-    {
-        scroll = (int8_t)buf[3];
-    }
-
-    // decode the new mouse packet
-    UiMouseEvent event = {};
-
-    event.offset.x = offx;
-    event.offset.y = -offy;
-    event.scroll.y = scroll;
-
-    event.buttons |= ((buf[0] >> 0) & 1) ? MSBTN_LEFT : 0;
-    event.buttons |= ((buf[0] >> 1) & 1) ? MSBTN_RIGHT : 0;
-    event.buttons |= ((buf[0] >> 2) & 1) ? MSBTN_MIDDLE : 0;
-
-    ps2_mouse_handle_event(ps2, event);
-}
-
-void ps2_mouse_handle_code(Ps2 *ps2, uint8_t packet)
-{
-    switch (ps2->mouse_cycle)
-    {
-    case 0:
-        ps2->mouse_buf[0] = packet;
-        if (ps2->mouse_buf[0] & 8)
-        {
-            ps2->mouse_cycle++;
-        }
-        break;
-    case 1:
-        ps2->mouse_buf[1] = packet;
-        ps2->mouse_cycle++;
-        break;
-    case 2:
-        ps2->mouse_buf[2] = packet;
-
-        if (ps2->mouse_has_wheel)
-        {
-            ps2->mouse_cycle++;
-        }
-        else
-        {
-            ps2_mouse_handle_finished(ps2);
-            ps2->mouse_cycle = 0;
-        }
-
-        break;
-    case 3:
-        ps2->mouse_buf[3] = packet;
-
-        ps2_mouse_handle_finished(ps2);
-        ps2->mouse_cycle = 0;
-        break;
-    }
-}
-
-void ps2_mouse_wait(Ps2 *ps2, int type)
-{
-    int timeout = 100000;
-    while (timeout--)
-    {
-        if (type == 0)
-        {
-            if ((bal_io_in8(ps2->io, PS2_REG_STATUS) & 1) == 1)
-            {
-                break;
-            }
-        }
-        else
-        {
-            if ((bal_io_in8(ps2->io, PS2_REG_STATUS) & 2) == 0)
-            {
-                break;
-            }
-        }
-    }
-}
-
-void ps2_mouse_write(Ps2 *ps2, uint8_t data)
-{
-    ps2_mouse_wait(ps2, 1);
-    bal_io_out8(ps2->io, PS2_REG_STATUS, 0xD4);
-    ps2_mouse_wait(ps2, 1);
-    bal_io_out8(ps2->io, PS2_REG_BUF, data);
-}
-
-uint8_t ps2_mouse_read(Ps2 *ps2)
-{
-    ps2_mouse_wait(ps2, 0);
-    return bal_io_in8(ps2->io, PS2_REG_BUF);
-}
-
-void ps2_mouse_init(Ps2 *ps2)
-{
-    // Enable the auxiliary mouse device
-    ps2_mouse_wait(ps2, 1);
-    bal_io_out8(ps2->io, PS2_REG_STATUS, 0xA8);
-
-    // Enable the interrupts
-    ps2_mouse_wait(ps2, 1);
-    bal_io_out8(ps2->io, PS2_REG_STATUS, 0x20);
-    ps2_mouse_wait(ps2, 0);
-    uint8_t status = (bal_io_in8(ps2->io, PS2_REG_BUF) | 3);
-    ps2_mouse_wait(ps2, 1);
-    bal_io_out8(ps2->io, PS2_REG_STATUS, 0x60);
-    ps2_mouse_wait(ps2, 1);
-    bal_io_out8(ps2->io, PS2_REG_BUF, status);
-
-    // Tell the mouse to use default settings
-    ps2_mouse_write(ps2, 0xF6);
-    ps2_mouse_read(ps2); // Acknowledge
-
-    // Enable the mouse
-    ps2_mouse_write(ps2, 0xF4);
-    ps2_mouse_read(ps2); // Acknowledge
-
-    // Try to  enable the scrollwhell
-    ps2_mouse_write(ps2, 0xF2);
-    ps2_mouse_read(ps2);
-
-    ps2_mouse_read(ps2);
-    ps2_mouse_write(ps2, 0xF3);
-    ps2_mouse_read(ps2);
-    ps2_mouse_write(ps2, 200);
-    ps2_mouse_read(ps2);
-
-    ps2_mouse_write(ps2, 0xF3);
-    ps2_mouse_read(ps2);
-    ps2_mouse_write(ps2, 100);
-    ps2_mouse_read(ps2);
-
-    ps2_mouse_write(ps2, 0xF3);
-    ps2_mouse_read(ps2);
-    ps2_mouse_write(ps2, 80);
-    ps2_mouse_read(ps2);
-
-    ps2_mouse_write(ps2, 0xF2);
-    ps2_mouse_read(ps2);
-
-    uint8_t result = ps2_mouse_read(ps2);
-    ps2->mouse_has_wheel = result == 3;
-    if (ps2->mouse_has_wheel)
-    {
-        log$("Mouse has a wheel");
-    }
-    else
-    {
-        log$("Mouse don't have a wheel");
-    }
-}
-
-void ps2_handle_irq(void *ctx, BrEvent event)
-{
-    Ps2 *ps2 = ctx;
-
-    uint8_t status = bal_io_in8(ps2->io, PS2_REG_STATUS);
-
-    while (status & PS2_STATUS_FULL)
-    {
-        uint8_t is_mouse_buf = status & PS2_STATUS_MOUSE;
-
-        uint8_t packet = bal_io_in8(ps2->io, PS2_REG_BUF);
-
-        if (is_mouse_buf)
-        {
-            ps2_mouse_handle_code(ps2, packet);
-        }
-        else
-        {
-            ps2_keyboard_handle_code(ps2, packet);
-        }
-
-        status = bal_io_in8(ps2->io, PS2_REG_STATUS);
-    }
-
-    bal_ack(event);
-}
 
 int ipc_component_main(IpcComponent *self)
 {
-    Ps2 ps2 = {
-        .io = bal_io_port(0x60, 0x8),
-    };
+    Ps2 ps2 = {};
+    Ps2Ctx ctx = {};
+    init_ps2_mouse(&ps2, &ps2_mouse_callback, &ctx);
+    init_ps2_keyboard(&ps2, &ps2_keyboard_callback, &ctx);
 
-    ps2_mouse_init(&ps2);
+    ctx.input_sink = ipc_component_require(self, IPC_EVENT_SINK_PROTO);
 
-    ps2.input_sink = ipc_component_require(self, IPC_EVENT_SINK_PROTO);
+    BrIpcArgs ipc;
+    ipc.flags = BR_IPC_RECV | BR_IPC_BLOCK;
+    ipc.deadline = BR_DEADLINE_INFINITY;
 
-    BrEvent keyboard_irq = {.type = BR_EVENT_IRQ, .irq = 1};
-    BrEvent mouse_irq = {.type = BR_EVENT_IRQ, .irq = 12};
 
-    ipc_component_bind(self, keyboard_irq, ps2_handle_irq, &ps2);
-    ipc_component_bind(self, mouse_irq, ps2_handle_irq, &ps2);
+    while (br_ipc(&ipc) == BR_SUCCESS)
+    {
+        BrMsg msg = ipc.msg;
+
+        if (br_addr_eq(msg.from, BR_ADDR_EVENT) && msg.event.type == BR_EVENT_IRQ)
+        {
+
+            ps2_interrupt_handle(&ps2, msg.event);
+        }
+        else
+        {
+            log$("Unknown message!");
+        }
+    }
 
     return ipc_component_run(self);
 }

--- a/sources/pkgs/ps2/main.c
+++ b/sources/pkgs/ps2/main.c
@@ -3,11 +3,11 @@
 #include <brutal/alloc.h>
 #include <brutal/debug.h>
 #include <brutal/ui.h>
+#include <hw/ps2/ps2.h>
 #include <ipc/ipc.h>
 #include <protos/event.h>
 #include "bal/abi/types.h"
 #include "brutal/ui/event.h"
-#include <hw/ps2/ps2.h>
 
 typedef struct
 {
@@ -16,61 +16,41 @@ typedef struct
     IpcCap input_sink;
 } Ps2Ctx;
 
-void ps2_keyboard_callback(UiKeyboardEvent ev, void* ps2)
+void ps2_keyboard_callback(UiKeyboardEvent ev, void *ps2)
 {
     bool handled = false;
 
-     UiEvent event = {
+    UiEvent event = {
         .type = UI_EVENT_KEYBOARD_TYPED,
         .keyboard = ev,
     };
 
+    log$("ps2kb: key={} motion={}", kbkey_to_str(ev.key), ev.motion ? "down" : "up");
 
-    event_sink_dispatch_rpc(ipc_component_self(), ((Ps2Ctx*)ps2)->input_sink, &event, &handled, alloc_global());
+    event_sink_dispatch_rpc(ipc_component_self(), ((Ps2Ctx *)ps2)->input_sink, &event, &handled, alloc_global());
 }
 
-void ps2_mouse_callback(UiMouseEvent ev, void* ps2)
+void ps2_mouse_callback(UiMouseEvent ev, void *ps2)
 {
     bool handled = false;
 
-     UiEvent event = {
+    UiEvent event = {
         .type = UI_EVENT_MOUSE_MOVE,
         .mouse = ev,
     };
 
-
-    event_sink_dispatch_rpc(ipc_component_self(), ((Ps2Ctx*)ps2)->input_sink, &event, &handled, alloc_global());
+    event_sink_dispatch_rpc(ipc_component_self(), ((Ps2Ctx *)ps2)->input_sink, &event, &handled, alloc_global());
 }
-
 
 int ipc_component_main(IpcComponent *self)
 {
     Ps2 ps2 = {};
     Ps2Ctx ctx = {};
+    init_ps2(&ps2, self);
     init_ps2_mouse(&ps2, &ps2_mouse_callback, &ctx);
     init_ps2_keyboard(&ps2, &ps2_keyboard_callback, &ctx);
 
     ctx.input_sink = ipc_component_require(self, IPC_EVENT_SINK_PROTO);
-
-    BrIpcArgs ipc;
-    ipc.flags = BR_IPC_RECV | BR_IPC_BLOCK;
-    ipc.deadline = BR_DEADLINE_INFINITY;
-
-
-    while (br_ipc(&ipc) == BR_SUCCESS)
-    {
-        BrMsg msg = ipc.msg;
-
-        if (br_addr_eq(msg.from, BR_ADDR_EVENT) && msg.event.type == BR_EVENT_IRQ)
-        {
-
-            ps2_interrupt_handle(&ps2, msg.event);
-        }
-        else
-        {
-            log$("Unknown message!");
-        }
-    }
 
     return ipc_component_run(self);
 }

--- a/sources/pkgs/ps2/ps2.h
+++ b/sources/pkgs/ps2/ps2.h
@@ -1,2 +1,1 @@
 #pragma once
-

--- a/sources/pkgs/ps2/ps2.h
+++ b/sources/pkgs/ps2/ps2.h
@@ -1,9 +1,2 @@
 #pragma once
 
-#define PS2_REG_BUF 0x0
-#define PS2_REG_STATUS 0x4
-
-#define PS2_STATUS_FULL 0x01
-#define PS2_STATUS_MOUSE 0x20
-
-#define PS2_KEYBOARD_ESCAPE 0xE0


### PR DESCRIPTION
Rework the ps2 code, now we use directly interruption for detecting wich device should handle the packet (we still use the status bit for checking too). This fix the bug were we weren't able to use the keyboard while moving the mouse. 