### PR TITLE
everywhere: fix typo 'failing' instead of 'failling'

### DIFF
--- a/sources/kernel/x86_64/cpuid.c
+++ b/sources/kernel/x86_64/cpuid.c
@@ -12,7 +12,7 @@ CpuidResult cpuid(uint32_t leaf, uint32_t subleaf)
 
     if (leaf > cpuid_max)
     {
-        log$("CPUID failled leaf:{} subleaf:{}", leaf, subleaf);
+        log$("CPUID failed leaf:{} subleaf:{}", leaf, subleaf);
         return (CpuidResult){.succ = false};
     }
 

--- a/sources/libs/brutal/alloc/heap.c
+++ b/sources/libs/brutal/alloc/heap.c
@@ -28,7 +28,7 @@ static HeapMajor *major_block_create(size_t size, NodeSize node_size)
     HeapMajor *maj;
     if (embed_mem_acquire(st * MEM_PAGE_SIZE, (void **)&maj, EMBED_MEM_NONE).kind != ERR_KIND_SUCCESS)
     {
-        panic$("Failled to allocate memory!");
+        panic$("Failed to allocate memory!");
     }
 
     maj->prev = nullptr;

--- a/sources/libs/brutal/base/result.h
+++ b/sources/libs/brutal/base/result.h
@@ -71,4 +71,4 @@
     })
 
 #define UNWRAP(EXPR) \
-    UNWRAP_OR_PANIC(EXPR, "UNWRAP(" #EXPR ") failled")
+    UNWRAP_OR_PANIC(EXPR, "UNWRAP(" #EXPR ") failed")

--- a/sources/libs/stdc-ansi/assert.h
+++ b/sources/libs/stdc-ansi/assert.h
@@ -2,7 +2,7 @@
 
 /* --- 7.2 Diagnostics ------------------------------------------------------ */
 
-void assert_failled_impl(void);
+void assert_failed_impl(void);
 
 #ifdef NDEBUG
 #    define assert(expr) (void)(expr)
@@ -10,7 +10,7 @@ void assert_failled_impl(void);
 #    define assert(expr)           \
         if (!expr)                 \
         {                          \
-            assert_failled_impl(); \
+            assert_failed_impl(); \
         }
 #endif
 


### PR DESCRIPTION
Fix grammatical mistakes. The ones changed are the only occurrences of the misspelled word "fail".