### PR TITLE
std: define noreturn instead of using deprecated '<stdnoreturn.h>' header

### DIFF
--- a/sources/libs/brutal/base/std.h
+++ b/sources/libs/brutal/base/std.h
@@ -5,4 +5,5 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdnoreturn.h>
+
+#define noreturn _Noreturn


### PR DESCRIPTION
This should fix #118 