### PR TITLE
Make it compile on macOS (Monterey)

### DIFF
--- a/makefile
+++ b/makefile
@@ -32,7 +32,11 @@ BASE_CFLAGS += \
 	-Isources/srvs \
 	-Isources/utils \
 	-Isources/ \
-	-Ibin/generated
+	-Ibin/generated \
+	-Wno-unused-label \
+	-Wno-unused-function \
+	-Wno-unused-parameter \
+	-Wno-unused-variable
 
 USER_CFLAGS_INC := \
 	-Isources/libs/stdc-ansi \


### PR DESCRIPTION
I used this configuration to compile it under macOS (Monterey).

I need to obtain the following dependencies on my local system to compile it.

`brew install qemu nasm xorriso llvm binutils wget`

Then I run it via `./brutal.sh -r` to open the `qemu` window.