### PR TITLE
docs: Fix a few typos

### DIFF
--- a/meta/scheduling.md
+++ b/meta/scheduling.md
@@ -2,7 +2,7 @@
 
 ## The Context
 
-For an os, scheduling is very important, its need to be optimized, fast, and responsive. We needed a scheduler that support multiple CPU. We also needed a scheduler that did the least task switch possible. For exemple, in a system with 4 cpu and 4 task we may have:
+For an os, scheduling is very important, its need to be optimized, fast, and responsive. We needed a scheduler that support multiple CPU. We also needed a scheduler that did the least task switch possible. For example, in a system with 4 cpu and 4 task we may have:
 
 | cpu    | 1   | 2   | 3   | 4   |
 | ------ | --- | --- | --- | --- |
@@ -83,7 +83,7 @@ That's why we have 2 part of the scheduler:
 
 ## When The Number Of Running Processes Is Lower Than The Number Of Cpu
 
-If the number of processes is lower than the number of cpu we don't need to switch context. But if we have 1 process that started running and it does not execute code we need to assign him a cpu. That's why we have 'idle cpu'. Lazy cpu are cpu that don't do anything for the moment. For exemple if we have 3 process and 5 core, we have 2 idle cpu. So if a cpu is idle and there is a process waiting to run, we give the process to the idle cpu. For cpu that are already running a process we just put the same process as the next process.
+If the number of processes is lower than the number of cpu we don't need to switch context. But if we have 1 process that started running and it does not execute code we need to assign him a cpu. That's why we have 'idle cpu'. Lazy cpu are cpu that don't do anything for the moment. For example if we have 3 process and 5 core, we have 2 idle cpu. So if a cpu is idle and there is a process waiting to run, we give the process to the idle cpu. For cpu that are already running a process we just put the same process as the next process.
 
 ## When The Number Of Running Processes Is Higher Than The Number Of Cpu
 
@@ -97,7 +97,7 @@ size_t schedule_count = m_min(cpu_count(), running - cpu_count());
 
 We can't switch higher than the cpu_count (we can't switch for 6 process using 5 cpu) and we can't switch more process than there is cpu (we can't switch for 1 process for 5 cpu).
 
-For each `schedule_count` we get the process that has run the longest and replace it with the process that waited the longest. But we can still have the case where we have a idle cpu. For exemple if a process is deleted or sleeping so when we get the most waiting process, we check if there is no idle cpu. If there is one, put the most waiting process in the idle cpu. If there is not replace the most running process with the most waiting process.
+For each `schedule_count` we get the process that has run the longest and replace it with the process that waited the longest. But we can still have the case where we have a idle cpu. For example if a process is deleted or sleeping so when we get the most waiting process, we check if there is no idle cpu. If there is one, put the most waiting process in the idle cpu. If there is not replace the most running process with the most waiting process.
 
 ## CPU Cache Is Important
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@
 <br>
 
 - **BRUTAL** is an operating system built from scratch in modern C.
-- **BRUTAL** is built on top of a capabilty based micro-kernel.
+- **BRUTAL** is built on top of a capability based micro-kernel.
 - **BRUTAL** targets x86_64, i686, RISC-V and ARM.
 - **BRUTAL** exposes its features to developers through clean APIs.
 - **BRUTAL** features a rich and modern C library complete with fibers, custom allocators, generic data structures, and more...

--- a/sources/kernel/riscv64/asm.h
+++ b/sources/kernel/riscv64/asm.h
@@ -8,7 +8,7 @@ enum csr_regs
     CSR_SISA = 0x101,    // supervisor extension
     CSR_SIE = 0x104,     // supervisor interrupt enable
     CSR_STVEC = 0x105,   // supervisor trap vector
-    CSR_SEPC = 0x141,    // supervisor trap programm counter
+    CSR_SEPC = 0x141,    // supervisor trap program counter
     CSR_SCAUSE = 0x142,  // supervisor trap cause
     CSR_STVAL = 0x143,   // supervisor trap value
     CSR_SIP = 0x144,     // supervisor interrupt pending

--- a/sources/kernel/riscv64/unleashed/gpio.h
+++ b/sources/kernel/riscv64/unleashed/gpio.h
@@ -8,7 +8,7 @@ enum gpio_registers
     GPIO_INPUT_ENABLE = 4,
     GPIO_OUTPUT_ENABLE = 8,
     GPIO_OUTPUT_VAL = 12,
-    GPIO_INTERNAL_PU_ENABLE = 16, // internall pull up
+    GPIO_INTERNAL_PU_ENABLE = 16, // internal pull up
     GPIO_PIN_DRIVE_STENGTH = 20,
     GPIO_RISE_INT_ENABLE = 24,
     GPIO_RISE_INT_PENDING = 28,

--- a/sources/kernel/x86_64/asm.h
+++ b/sources/kernel/x86_64/asm.h
@@ -205,7 +205,7 @@ enum rflags_bit
     RFLAGS_RESERVED4_ZERO = 1 << 15, // reserved, must be 0
     RFLAGS_RESUME = 1 << 16,
     RFLAGS_VIRTUAL_8086 = 1 << 17,     // good ol' time
-    RFLAGS_ALIGNEMENT_CHECK = 1 << 18, // check each memory alignement
+    RFLAGS_Alignment_CHECK = 1 << 18, // check each memory alignment
     RFLAGS_ACCESS_CONTROL = 1 << 18,
     RFLAGS_VIRTUAL_INTERRUPT = 1 << 19,         // same as INTERRUPT_ENABLE for virtual interrupts
     RFLAGS_VIRTUAL_INTERRUPT_PENDING = 1 << 20, //

--- a/sources/kernel/x86_64/asm.h
+++ b/sources/kernel/x86_64/asm.h
@@ -205,7 +205,7 @@ enum rflags_bit
     RFLAGS_RESERVED4_ZERO = 1 << 15, // reserved, must be 0
     RFLAGS_RESUME = 1 << 16,
     RFLAGS_VIRTUAL_8086 = 1 << 17,     // good ol' time
-    RFLAGS_Alignment_CHECK = 1 << 18, // check each memory alignment
+    RFLAGS_ALIGNEMENT_CHECK = 1 << 18, // check each memory alignment
     RFLAGS_ACCESS_CONTROL = 1 << 18,
     RFLAGS_VIRTUAL_INTERRUPT = 1 << 19,         // same as INTERRUPT_ENABLE for virtual interrupts
     RFLAGS_VIRTUAL_INTERRUPT_PENDING = 1 << 20, //

--- a/sources/kernel/x86_64/com.c
+++ b/sources/kernel/x86_64/com.c
@@ -64,7 +64,7 @@ void com_initialize(enum com_port port)
     com_write_reg(port, COM_BAUD_RATE_LOW, 115200 / 9600);
     com_write_reg(port, COM_BAUD_RATE_HIGH, 0);
 
-    // we want 8bit caracters + clear dlab
+    // we want 8bit characters + clear dlab
     com_write_reg(port, COM_LINE_CONTROL, COM_DATA_SIZE_8);
 
     // turn on communication + redirect UART interrupt into ICU

--- a/sources/utils/test/cc/cc.h
+++ b/sources/utils/test/cc/cc.h
@@ -3,7 +3,7 @@
 #include <cc/parse.h>
 #include <brutal-io>
 
-// FIXME: get ride of thoses ugly macros.
+// FIXME: get ride of those ugly macros.
 
 #define ctx_lex(lexer_name, str)                     \
     Scan _scan = {};                                 \


### PR DESCRIPTION
There are small typos in:
- meta/scheduling.md
- readme.md
- sources/kernel/riscv64/asm.h
- sources/kernel/riscv64/unleashed/gpio.h
- sources/kernel/x86_64/asm.h
- sources/kernel/x86_64/com.c
- sources/utils/test/cc/cc.h

Fixes:
- Should read `example` rather than `exemple`.
- Should read `those` rather than `thoses`.
- Should read `program` rather than `programm`.
- Should read `internal` rather than `internall`.
- Should read `characters` rather than `caracters`.
- Should read `capability` rather than `capabilty`.
- Should read `alignment` rather than `alignement`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md